### PR TITLE
Fix travis build

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -17,6 +17,7 @@ install_nodejs() {
   # running this in a subshell
   # we don't want to disturb current working dir
   (
+    mkdir -p $install_path
     if [ "$install_type" != "version" ]; then
       tar zxf $source_path -C $install_path --strip-components=1 || exit 1
       cd $install_path


### PR DESCRIPTION
This should fix travis build. It is not needed in normal execution context,
as the directory should be present, but it should not hurt either.