### PR TITLE
Add cases for armv7 architectures

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -60,14 +60,19 @@ construct_configure_options() {
 
 
 os_based_configure_options() {
-  local operating_system=$(uname -a)
+  local operating_system=$(uname -m)
   local configure_options=""
 
-  if [[ "$operating_system" =~ "x86_64" ]]; then
+  case "$operating_system" in
+  x86_64)
     local cpu_type="x64"
-  else
+    ;;
+  armv7l)
+    local cpu_type="armv7l"
+    ;;
+  *)
     local cpu_type="x86"
-  fi
+  esac
 
   configure_options="$configure_options --dest-cpu=$cpu_type"
   echo $configure_options
@@ -91,11 +96,16 @@ get_download_file_path() {
 
 
   if [ "$install_type" = "version" ]; then
-    if [[ "$operating_system" =~ "x86_64" ]]; then
+    case "$operating_system" in
+    *"x86_64"*)
       local cpu_type="x64"
-    else
+      ;;
+    *"armv7l"*)
+      local cpu_type="armv7l"
+      ;;
+    *)
       local cpu_type="x86"
-    fi
+    esac
 
     if [[ "$operating_system" =~ "Darwin" ]]; then
       local pkg_name="node-v${version}-darwin-${cpu_type}"
@@ -116,11 +126,16 @@ get_download_url() {
   local operating_system=$(uname -a)
 
   if [ "$install_type" = "version" ]; then
-    if [[ "$operating_system" =~ "x86_64" ]]; then
+    case "$operating_system" in
+    *"x86_64"*)
       local cpu_type="x64"
-    else
+      ;;
+    *"armv7l"*)
+      local cpu_type="armv7l"
+      ;;
+    *)
       local cpu_type="x86"
-    fi
+    esac
 
     if [[ "$operating_system" =~ "Darwin" ]]; then
       echo "http://nodejs.org/dist/v${version}/node-v${version}-darwin-${cpu_type}.tar.gz"


### PR DESCRIPTION
This appears to fix asdf-nodejs support on my Raspberry Pi.

I could use a little help though. I ran `asdf plugin-test nodejs https://github.com/jwashton/asdf-nodejs.git 'node --version'` on both my machine (x86_64 Fedora 23) and the Pi. It worked as expected on the Pi, and appeared to work okay on Fedora **except that** it didn't print out the version number. I used my changes to install node 6.2.2 on x86_64 Fedora successfully, and I don't seem to be having any problems with it, but I'm not sure I could say the test "passed".

I'm also new to bash programming, so there are probably ways that this could have been done better that I am unfamiliar with.

But hey, this is a start. :)
