### PR TITLE
Add 0.10.x and 0.11.x nodejs versions to list-all script.

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -2,5 +2,5 @@
 
 echo $(
   curl --silent http://semver.io/node/versions \
-  | grep -E -v '^0\.([0-9]|10|11)\.'
+  | grep -E -v '^0\.([0-9])\.'
 )


### PR DESCRIPTION
asdf-nodejs seems to work fine with 0.10.47 and I didn't have time to test with other the other versions.

This should resolve issue #18 