### PR TITLE
support arm 64bit (arm8)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -76,6 +76,7 @@ get_nodejs_machine_hardware_name() {
   case "$machine_hardware_name" in
     'x86_64') local cpu_type="x64";;
     'i686') local cpu_type="x86";;
+    'aarch64') local cpu_type="arm64";;
     *) local cpu_type="$machine_hardware_name";;
   esac
 


### PR DESCRIPTION
uname -m returns aarch64 on some arm8 systems.

however nodejs serves the file as 'arm64' (eg. https://nodejs.org/dist/v6.10.3/node-v6.10.3-linux-arm64.tar.xz)

the arm6 and arm7 filenames looks to be correct.