### PR TITLE
Support vX.X.X version name in legacy version file

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo $(
+  sed '1 s/^v//' $1
+)


### PR DESCRIPTION
For `.node-version` files, the version name was sometimes written in _v6.10.2_ format.  Which cause asdf can't locate the installed version while using `legacy_version_file`.