### PR TITLE
Readme: clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,20 @@ Node.js plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Requirements
 
-* _(MacOS)_ [GNU Core Utils](http://www.gnu.org/software/coreutils/coreutils.html˙˚) - `brew install coreutils`
+* _(MacOS)_ [GNU Core Utils](http://www.gnu.org/software/coreutils/coreutils.html) - `brew install coreutils`
+* _(MacOS)_ [GnuPG](http://www.gnupg.org) - `brew install gpg`
 
 ## Install
 
-```
-asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+Install the plugin:
 
-# Imports Node.js release team's OpenPGP keys to main keyring
+```bash
+asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+```
+
+Import the Node.js release team's OpenPGP keys to main keyring:
+
+```bash
 bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
 ```
 


### PR DESCRIPTION
My co workers always miss the `import-release-team-keyring` step, hopefully this makes it more obvious.