### PR TITLE
use explicit hkp to port 80

### DIFF
--- a/bin/import-previous-release-team-keyring
+++ b/bin/import-previous-release-team-keyring
@@ -13,6 +13,6 @@ SERVERS="ipv4.pool.sks-keyservers.net \
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    gpg --keyserver $server --recv-keys $key && break
+    gpg --keyserver hkp://$server:80 --recv-keys $key && break
   done
 done

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -17,6 +17,6 @@ SERVERS="ipv4.pool.sks-keyservers.net \
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    gpg --keyserver $server --recv-keys $key && break
+    gpg --keyserver hkp://$server:80 --recv-keys $key && break
   done
 done


### PR DESCRIPTION
avoid timeout on system where port 11371 is blocked
this is not uncommon, and than the user experience is rather bad

with this change, what's written in the readme should work everywhere