### PR TITLE
Fix Issue #56: Can't install latest version of npm globally

### DIFF
--- a/bin/exec-path
+++ b/bin/exec-path
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+install_path=$1
+cmd=$2
+executable_path=$3
+
+if [[ "$cmd" == "npm" ]] || [[ "$cmd" == "npx" ]]; then
+  npm_bin_cmd=".npm/bin/$cmd"
+
+  if [[ -f "$install_path/$npm_bin_cmd" ]]; then
+    executable_path="$npm_bin_cmd"
+  fi
+fi
+
+echo "$executable_path"


### PR DESCRIPTION
Fix for issue #56 

Note: This is based on the new feature in `asdf` (PR - https://github.com/asdf-vm/asdf/pull/314)

The idea is to allow plugins to override the shim's specified executable path. In the case of `npm` the command may exist in one of 2 locations (`bin/npm` - by install or `.npm/bin/npm` - if upgraded manually).