### PR TITLE
Fix issue #67: Default packages don't install correctly

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -234,8 +234,8 @@ install_default_npm_packages() {
 
   for name in $(cat $default_npm_packages); do
     echo -ne "\nInstalling \e[33m${name}\e[39m npm package... "
-
-    if npm install -g $name > /dev/null 2>&1; then
+    PATH="$PATH:$ASDF_INSTALL_PATH/bin" npm install -g $name > /dev/null 2>&1
+    if [[ $? -eq 0 ]]; then
       echo -e "\e[32mSUCCESS\e[39m"
     else
       echo -e "\e[31mFAIL\e[39m"


### PR DESCRIPTION
Override PATH env when calling npm install

A bug existed where, if no versions of `node` and `npm` are installed already, running `asdf install node <version>` while having any packages listed inside `.default-npm-packages` would fail to install those
default packages because the newly installed node version's `bin` directory is not in the `PATH` yet.

Fixes #67