### PR TITLE
Allow setting nodejs mirror url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -4,6 +4,14 @@ set -o nounset -o pipefail -o errexit
 
 NODEJS_CHECK_SIGNATURES="${NODEJS_CHECK_SIGNATURES:-strict}"
 
+# When in China, set $NODEJS_ORG_MIRROR:
+# export NODEJS_ORG_MIRROR=https://npm.taobao.org/mirrors/node/
+NODEJS_ORG_MIRROR="${NODEJS_ORG_MIRROR:-https://nodejs.org/dist/}"
+if [ ${NODEJS_ORG_MIRROR: -1} != / ]
+then
+  NODEJS_ORG_MIRROR=$NODEJS_ORG_MIRROR/
+fi
+
 install_nodejs() {
   local install_type="$1"
   local version="$2"
@@ -113,7 +121,7 @@ get_download_url() {
   local version="$2"
 
   if [ "$install_type" = "version" ]; then
-    local download_url_base="https://nodejs.org/dist/v${version}"
+    local download_url_base="${NODEJS_ORG_MIRROR}v${version}"
   else
     local download_url_base="https://github.com/nodejs/node/archive"
   fi
@@ -127,7 +135,7 @@ get_signed_checksum_download_url() {
   local version=$2
 
   if [ "$install_type" = "version" ]; then
-    echo "https://nodejs.org/dist/v${version}/SHASUMS256.txt.asc"
+    echo "${NODEJS_ORG_MIRROR}v${version}/SHASUMS256.txt.asc"
   else
     # Not implemented.
     exit 1


### PR DESCRIPTION
The download speed in China is quite slow, because we have difficulty accessing [https://nodejs.org/dist/](https://nodejs.org/dist/). It would be nice if adding a new environment variable, for example, `NODEJS_ORG_MIRROR` to download binaries from local mirror.

Download from origin url:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 17.2M    0  136k    0     0  12592      0  0:23:55  0:00:11  0:23:44 14189
```

Download from taobao mirror:
```bash
export NODEJS_ORG_MIRROR=https://npm.taobao.org/mirrors/node/
```

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   173  100   173    0     0   1226      0 --:--:-- --:--:-- --:--:--  1226
 81 17.2M   81 14.1M    0     0  2244k      0  0:00:07  0:00:06  0:00:01 2218k
```
