### PR TITLE
Add more keyservers

### DIFF
--- a/bin/import-previous-release-team-keyring
+++ b/bin/import-previous-release-team-keyring
@@ -10,15 +10,15 @@ KEYS="9554F04D7259F04124DE6B476D5A82AC7E37093B \
       7937DFD2AB06298B2293C3187D33FF9D0246406D"
 
 SERVERS="ha.pool.sks-keyservers.net
-         hkp://p80.pool.sks-keyservers.net:80 \
-         hkp://ipv4.pool.sks-keyservers.net \
+         p80.pool.sks-keyservers.net:80 \
+         ipv4.pool.sks-keyservers.net \
          keyserver.ubuntu.com
-         hkp://keyserver.ubuntu.com:80 \
+         keyserver.ubuntu.com:80 \
          pgp.mit.edu
-         hkp://pgp.mit.edu:80"
+         pgp.mit.edu:80"
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    gpg --keyserver "$server" --recv-keys "$key" && break
+    gpg --keyserver "hkp://$server" --recv-keys "$key" && break
   done
 done

--- a/bin/import-previous-release-team-keyring
+++ b/bin/import-previous-release-team-keyring
@@ -9,12 +9,16 @@ KEYS="9554F04D7259F04124DE6B476D5A82AC7E37093B \
       56730D5401028683275BD23C23EFEFE93C4CFFFE \
       7937DFD2AB06298B2293C3187D33FF9D0246406D"
 
-
-SERVERS="ipv4.pool.sks-keyservers.net \
-         pgp.mit.edu"
+SERVERS="ha.pool.sks-keyservers.net
+         hkp://p80.pool.sks-keyservers.net:80 \
+         hkp://ipv4.pool.sks-keyservers.net \
+         keyserver.ubuntu.com
+         hkp://keyserver.ubuntu.com:80 \
+         pgp.mit.edu
+         hkp://pgp.mit.edu:80"
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    gpg --keyserver hkp://$server:80 --recv-keys $key && break
+    gpg --keyserver "$server" --recv-keys "$key" && break
   done
 done

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -12,11 +12,16 @@ KEYS="94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
       8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
       77984A986EBC2AA786BC0F66B01FBB92821C587A"
 
-SERVERS="ipv4.pool.sks-keyservers.net \
-         pgp.mit.edu"
+SERVERS="ha.pool.sks-keyservers.net
+         hkp://p80.pool.sks-keyservers.net:80 \
+         hkp://ipv4.pool.sks-keyservers.net \
+         keyserver.ubuntu.com
+         hkp://keyserver.ubuntu.com:80 \
+         pgp.mit.edu
+         hkp://pgp.mit.edu:80"
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    gpg --keyserver hkp://$server:80 --recv-keys $key && break
+    gpg --keyserver "$server" --recv-keys "$key" && break
   done
 done

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -12,7 +12,7 @@ KEYS="94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
       8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
       77984A986EBC2AA786BC0F66B01FBB92821C587A"
 
-SERVERS="ha.pool.sks-keyservers.net
+SERVERS="hkp://ha.pool.sks-keyservers.net
          hkp://p80.pool.sks-keyservers.net:80 \
          hkp://ipv4.pool.sks-keyservers.net \
          keyserver.ubuntu.com

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -12,16 +12,16 @@ KEYS="94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
       8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
       77984A986EBC2AA786BC0F66B01FBB92821C587A"
 
-SERVERS="hkp://ha.pool.sks-keyservers.net
-         hkp://p80.pool.sks-keyservers.net:80 \
-         hkp://ipv4.pool.sks-keyservers.net \
+SERVERS="ha.pool.sks-keyservers.net
+         p80.pool.sks-keyservers.net:80 \
+         ipv4.pool.sks-keyservers.net \
          keyserver.ubuntu.com
-         hkp://keyserver.ubuntu.com:80 \
+         keyserver.ubuntu.com:80 \
          pgp.mit.edu
-         hkp://pgp.mit.edu:80"
+         pgp.mit.edu:80"
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    gpg --keyserver "$server" --recv-keys "$key" && break
+    gpg --keyserver "hkp://$server" --recv-keys "$key" && break
   done
 done


### PR DESCRIPTION
There are some additional protocols and keyservers we can try when trying to verify the binary with gpg.

While testing this, I realized that I cannot install nodejs 10.5.0+ because there's a release key (I think?) that's [not in their list on GitHub](https://github.com/nodejs/node#release-team). 

Also fixing some shellcheck warnings about quoting variables while I'm at it.