### PR TITLE
Add throttling to postinstall

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -1,3 +1,42 @@
 #!/usr/bin/env bash
 
-asdf reshim nodejs "$ASDF_INSTALL_VERSION"
+set -e
+
+declare LOCK_FILE="/tmp/asdf-nodejs-postinstall.lock.2ac8ccc4"
+declare last_called_file="/tmp/asdf-nodejs-postinstall.last_called.dd05fa02"
+declare -i throttle_by=10
+
+main() {
+    sleep $throttle_by
+
+    local -i last_called=0
+    local -i now=$(date +%s)
+
+    {
+        flock -s 200
+        touch "$last_called_file"
+        last_called="$(<"$last_called_file")"
+    } 200>"$LOCK_FILE"
+
+    if (($now - $last_called >= $throttle_by)); then
+        {
+            flock -x 200
+            touch "$last_called_file"
+            if (( $last_called == $(($(<"$last_called_file"))) )); then
+                >"$last_called_file" date +%s
+            else
+                exit 0
+            fi
+        } 200>"$LOCK_FILE"
+
+        asdf reshim nodejs "$ASDF_INSTALL_VERSION"
+
+        {
+            flock -x 200
+            touch "$last_called_file"
+            >"$last_called_file" date +%s
+        } 200>"$LOCK_FILE"
+    fi
+}
+
+main &


### PR DESCRIPTION
Installing any global packages is currently VERY slow.

It works by spawning the process in the background on every execution of the hook. It executes the reshim only if it's the last hook call within the last 10 seconds.

I've tested this one on Arch Linux. It works well and reduces the execution times for individual hook to the minimum.

You can test it by adding `echo ASDF RESHIM NODEJS` above `asdf reshim` command. Then execute `npm i -g npm`, it will call the hook a few hundred times, but the echo message should be displayed only once (with 10-second delay after last hook call).