### PR TITLE
Show proper error on invalid requested version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -96,7 +96,12 @@ download_file() {
   local download_url="$1"
   local download_path="$2"
 
-  curl -Lo "$download_path" -C - "$download_url"
+  STATUSCODE=$(curl --write-out "%{http_code}" -Lo "$download_path" -C - "$download_url")
+
+  if test $STATUSCODE -eq 404; then
+    echo "Binaries were not found. Full version must be specified, not just major version."
+    exit 1
+  fi
 }
 
 


### PR DESCRIPTION
I was installing nodejs like `asdf install nodejs 10` and once again I was trying to solve GPG signature validation errors, because I did not specified full version number. This PR shows proper error on invalid requested version.