### PR TITLE
Speed up npm global installs

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-asdf reshim nodejs "$ASDF_INSTALL_VERSION"
+asdf reshim nodejs "${ASDF_INSTALL_VERSION:-$npm_config_node_version}"


### PR DESCRIPTION
Per issue #46 the `ASDF_INSTALL_VERSION` variable is not available in global NPM installs. Instead the `npm_config_node_version` is provided by NPM during this situation.

This change offers a fallback in these cases. Since a version will be available this will significantly speed up the postinstall during global NPM installs.

Fixes #46