### PR TITLE
Add option to temporarily disable reshimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ request
 express
 ```
 
+## Temporarily disable reshimming
+
+To avoid a slowdown when installing large packages (see https://github.com/asdf-vm/asdf-nodejs/issues/46), you can `ASDF_SKIP_RESHIM=1 npm i -g <package>` and reshim after installing all packages using `asdf reshim nodejs`.
+
 ## Using a dedicated OpenPGP keyring
 
 The `gpg` commands above imports the OpenPGP public keys in your main OpenPGP keyring. However, you can also use a dedicated keyring in order to mitigate [this issue](https://github.com/nodejs/node/issues/9859).

--- a/bin/install
+++ b/bin/install
@@ -277,4 +277,5 @@ tmp_download_dir="$(mktemp -d -t 'asdf_nodejs_XXXXXX')"
 trap 'rm -rf "${tmp_download_dir}"' EXIT
 
 install_nodejs "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH" "$tmp_download_dir"
-install_default_npm_packages
+ASDF_SKIP_RESHIM=1 install_default_npm_packages
+asdf reshim nodejs "$ASDF_INSTALL_VERSION"

--- a/bin/postinstall
+++ b/bin/postinstall
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-asdf reshim nodejs "${ASDF_INSTALL_VERSION:-$npm_config_node_version}"
+if [ "$ASDF_SKIP_RESHIM" == "1" ]; then
+  echo "Run 'asdf reshim nodejs ${ASDF_INSTALL_VERSION:-$npm_config_node_version}' after installing the packets to reshim"
+else
+  asdf reshim nodejs "${ASDF_INSTALL_VERSION:-$npm_config_node_version}"
+fi


### PR DESCRIPTION
* Resolves slow install of npm packages when installing the default packages
* Adds an option to mitigate #46 when installing packages with many dependencies