### PR TITLE
Reshim only when needed

### DIFF
--- a/bin/postinstall
+++ b/bin/postinstall
@@ -5,6 +5,6 @@ source "$(dirname "$0")/../lib/utils.sh"
 
 if [ "$ASDF_SKIP_RESHIM" == "1" ]; then
   echo "Run 'asdf reshim $(plugin_name) ${ASDF_INSTALL_VERSION:-$npm_config_node_version}' after installing the packages to reshim"
-else
+elif [[ ! -z `/usr/bin/env | grep "npm_package_bin"` ]]; then
   asdf reshim "$(plugin_name)" "${ASDF_INSTALL_VERSION:-$npm_config_node_version}"
 fi


### PR DESCRIPTION
* Only reshims when npm packets are installed which have a binary
* ~I didn't find any documentation about the env variable `npm_package_bin_*`, but it seems that it is always `npm_package_bin_<bin_name>`, e.g. `npm_package_bin_prettier` for the package `prettier`~
* As pointed out by @augustobmoura, the documentation is [here](https://docs.npmjs.com/cli/v6/using-npm/scripts#packagejson-vars)