### PR TITLE
add package.json to legacy files

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo ".nvmrc .node-version"
+echo ".nvmrc .node-version package.json"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+
+if [ "$(basename "$1")" = "package.json" ]; then
+  jq_command=$(command -v jq)
+  if [ -z "$jq_command" ]; then
+    echo "jq not available for use" >&2
+    exit 1
+  fi
+
+  version=$("$jq_command" -r .engines.node "$1")
+  [ "$version" != "null" ] && echo "$version"
+  exit 0
+fi
+
 echo $(
   sed '1 s/^v//' "$1"
 )


### PR DESCRIPTION
This PR adds `package.json` to the list of legacy files, and uses [jq](https://stedolan.github.io/jq/) to read the value of `engines.node`.  It'll be limited to asdf-friendly values which fits our use-case, although [the docs](https://docs.npmjs.com/files/package.json#engines) say it could be specified as a range expression.

I wasn't sure how psyched folks would be to add a dependency on jq, nor how complete we'd like to be about handling values of `engines.node`, but at least this is a working proposal for closing #60.

Feedback welcome!