### PR TITLE
Use UTF-8 for output

### DIFF
--- a/bin/import-previous-release-team-keyring
+++ b/bin/import-previous-release-team-keyring
@@ -24,6 +24,6 @@ fi
 
 for key in $KEYS; do
   for server in $SERVERS; do
-      gpg --no-tty --keyserver "hkp://$server" $OPTIONS --recv-keys "$key" && break
+      gpg --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key" && break
   done
 done

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -30,6 +30,6 @@ fi
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    gpg --no-tty --keyserver "hkp://$server" $OPTIONS --recv-keys "$key"  && break
+    gpg --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key"  && break
   done
 done


### PR DESCRIPTION
This pull request explicitly sets the output to use the UTF-8 character set, this prevents the following error message:

```
gpg: conversion from 'utf-8' to 'US-ASCII' failed: Illegal byte sequence
gpg: key 770F7A9A5AE15600: "Micha�l Zasso (Targos) <targos@protonmail.com>" not changed
```

The error can also be fixed by setting "charset utf-8" in `~/.gnupg/gpg.conf` but this is not the default.