### PR TITLE
Use UTF-8 for output during installation

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -186,7 +186,7 @@ download_and_verify_checksums() {
           export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
       fi
 
-      if ! $gnugp_verify_command_name --verify "$signed_checksum_file"; then
+      if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file"; then
         echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet bootstrap trust. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
         exit 1
       fi


### PR DESCRIPTION
This pull request explicitly sets the output to use the UTF-8 character set during installation.

Before:
```
gpg: conversion from 'utf-8' to 'US-ASCII' failed: Illegal byte sequence
gpg: Good signature from "Micha�l Zasso (Targos) <targos@protonmail.com>" [unknown]
```

After:
```
gpg: Good signature from "Michaël Zasso (Targos) <targos@protonmail.com>" [unknown]
```

https://github.com/asdf-vm/asdf-nodejs/pull/121 previously fixed this only for when running the `import-release-team-keyring` command.