### PR TITLE
Fixes for `~/.default-npm-packages` install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -263,12 +263,12 @@ install_default_npm_packages() {
   if [ ! -f $default_npm_packages ]; then return; fi
 
   for name in $(cat $default_npm_packages); do
-    echo -ne "\nInstalling \e[33m${name}\e[39m npm package... "
+    echo -ne "\nInstalling \033[33m${name}\033[39m npm package... "
     PATH="$ASDF_INSTALL_PATH/bin:$PATH" npm install -g $name > /dev/null 2>&1
     if [[ $? -eq 0 ]]; then
-      echo -e "\e[32mSUCCESS\e[39m"
+      echo -e "\033[32mSUCCESS\033[39m"
     else
-      echo -e "\e[31mFAIL\e[39m"
+      echo -e "\033[31mFAIL\033[39m"
     fi
   done
 }

--- a/bin/install
+++ b/bin/install
@@ -260,12 +260,12 @@ verlte() {
 install_default_npm_packages() {
   local default_npm_packages="${HOME}/.default-npm-packages"
 
-  if [ ! -f $default_npm_packages ]; then return; fi
+  if [ ! -f "$default_npm_packages" ]; then return; fi
 
-  for name in $(cat $default_npm_packages); do
+  cat "$default_npm_packages" | while read -r name; do
     echo -ne "\nInstalling \033[33m${name}\033[39m npm package... "
-    PATH="$ASDF_INSTALL_PATH/bin:$PATH" npm install -g $name > /dev/null 2>&1
-    if [[ $? -eq 0 ]]; then
+    PATH="$ASDF_INSTALL_PATH/bin:$PATH" npm install -g "$name" > /dev/null 2>&1 && rc=$? || rc=$?
+    if [[ $rc -eq 0 ]]; then
       echo -e "\033[32mSUCCESS\033[39m"
     else
       echo -e "\033[31mFAIL\033[39m"


### PR DESCRIPTION
## Fix output colors

bash does not support `\e[31m` escape sequences. use `\033[31m` instead.

## Do not exit install script on npm install failures

The install script is run with `set -o errexit`, which causes it to exit
on npm install errors.

Keep `errexit` and get exit code with https://stackoverflow.com/a/15844901/1308089