### PR TITLE
Add wget as an option beside curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ When installing Node.js using `asdf install`, you can pass custom configure opti
 * `NODEJS_EXTRA_CONFIGURE_OPTIONS` - append these configure options along with ones that this plugin already uses
 * `NODEJS_CHECK_SIGNATURES` - `strict` is default. Other values are `no` and `yes`. Checks downloads against OpenPGP signatures from the Node.js release team.
 * `NODEJS_ORG_MIRROR` - official mirror `https://nodejs.org/dist/` is default. If you are in China, you can set it to `https://npm.taobao.org/mirrors/node/`.
+* `DOWNLOADER` - use wget as downloader (default is curl).
 
 ### `.nvmrc` and `.node-version` files
 

--- a/bin/install
+++ b/bin/install
@@ -91,8 +91,7 @@ get_nodejs_machine_hardware_name() {
   echo "$cpu_type"
 }
 
-
-download_file() {
+download_file_with_curl() {
   local download_url="$1"
   local download_path="$2"
 
@@ -104,6 +103,28 @@ download_file() {
   fi
 }
 
+download_file_with_wget() {
+  local download_url="$1"
+  local download_path="$2"
+
+  wget -q -O "$download_path" "$download_url" 2>&1
+
+  if [ $? -ne 0 ]; then
+    echo "Binaries were not found. Full version must be specified, not just major version."
+    exit 1
+  fi
+}
+
+download_file() {
+  local download_url="$1"
+  local download_path="$2"
+
+  if [ -n "${DOWNLOADER+1}" ]; then
+    download_file_with_wget  "${download_url}" "${download_path}"
+  else
+    download_file_with_curl "${download_url}" "${download_path}"
+  fi
+}
 
 get_archive_file_name() {
   local install_type="$1"


### PR DESCRIPTION
In some case, like me, curl unable to download nodejs source file as Cloudflare serves as cache / proxy for nodejs.org. Wget can fulfill this need so I add the option to specify via environment variable setting.