### PR TITLE
Use 'command' over 'which' to check for shasum

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -205,10 +205,10 @@ checkShasum ()
   local archive_file_name="${1}"
   local authentic_checksum_file="${2}"
 
-  if $(which sha256sum >/dev/null 2>&1); then
+  if $(command -v sha256sum >/dev/null 2>&1); then
     sha256sum \
       --check <(grep "\s${archive_file_name}$" "${authentic_checksum_file}")
-  elif $(which shasum >/dev/null 2>&1); then
+  elif $(command -v shasum >/dev/null 2>&1); then
     shasum \
       -a 256 \
       --check <(grep "\s${archive_file_name}$" "${authentic_checksum_file}")


### PR DESCRIPTION
'command' is a shell builtin on all current shells

'which' is not builtin to bash, and if the node 'which' package is installed, that package may interfere

See https://github.com/asdf-vm/asdf-nodejs/issues/137 for an example of that interference