### PR TITLE
Tell Travis to test against the current branch's latest commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin-test nodejs https://github.com/asdf-vm/asdf-nodejs.git
+script: asdf plugin test nodejs . --asdf-plugin-gitref $TRAVIS_BRANCH node --version
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh


### PR DESCRIPTION
## Context

The `asdf plugin-test nodejs https://github.com/asdf-vm/asdf-nodejs.git` would fetch the master branch from the git repo and thus the test would be performed against the master branch. This does not offer much value for contributor who wants Travis CI to test their branch/PR to ensure no regression is ever introduced.

So we need a way to tell Travis to test against the current branch than master branch.

## Changes

* Specify gitref in the test CLI