### PR TITLE
Align install PGP warning with README

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -190,7 +190,7 @@ download_and_verify_checksums() {
       fi
 
       if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
-        echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet bootstrap trust. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
+        echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
         exit 1
       fi
       ## Mitigates: https://github.com/nodejs/node/issues/6821


### PR DESCRIPTION
If you haven't imported the necessary PGP keys, the installer will print an error about "bootstrapping trust" and direct you to the README. However, the words "bootstrap" and "trust" never appear in the README.

This adjusts the warning to include some words that you can actually search the README for.

Relates to #40 