### PR TITLE
List curl as required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Node.js plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 * [dirmngr](https://packages.debian.org/sid/dirmngr) - `apt-get install
   dirmngr`
 * [GnuPG](http://www.gnupg.org) - `apt-get install gpg`
+* [curl](https://curl.haxx.se) - `apt-get install curl`
 
 ## Install
 


### PR DESCRIPTION
Not all Linux systems come with `curl` pre-installed: for example, a clean Ubuntu installation doesn't have `curl` by default. This causes the plugin to raise errors like the following one:

```
> env LANG=C asdf list-all nodejs
/home/user/.asdf/plugins/nodejs/bin/list-all: line 7: curl: command not found
```

Here I added `curl` among the required dependencies to let users install it before than trying to use the plugin.