### PR TITLE
Preparation for fixing #138

### DIFF
--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -38,6 +38,6 @@ fi
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    $gnugp_verify_command_name --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key"  && break
+    $gnugp_verify_command_name --no-default-keyring --keyring asdf-nodejs.gpg --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key"  && break
   done
 done

--- a/bin/install
+++ b/bin/install
@@ -189,9 +189,12 @@ download_and_verify_checksums() {
           export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
       fi
 
-      if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
-        echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet bootstrap trust. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
-        exit 1
+      if ! $gnugp_verify_command_name --keyring asdf-nodejs.gpg --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
+        # Try default keyring
+        if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
+          echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet bootstrap trust. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
+          exit 1
+        fi
       fi
       ## Mitigates: https://github.com/nodejs/node/issues/6821
       local authentic_checksum_file="$tmp_download_dir/authentic_SHASUMS256.txt"


### PR DESCRIPTION
Import and use gpg keys in separate keyring

Using separate gpg keyring file in
~/.gnupg/asdf-nodejs.gpg to avoid
mixing with default keyring