### PR TITLE
Move gpg keys to separate keyring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin test nodejs . --asdf-plugin-gitref $TRAVIS_BRANCH node --version
+script: asdf plugin test nodejs . --asdf-plugin-gitref HEAD node --version
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -2,6 +2,8 @@
 
 set -o nounset -o pipefail -o errexit
 
+source "$(dirname "$0")/../lib/utils.sh"
+
 ## Keys from https://github.com/nodejs/node/#release-keys
 KEYS="94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
       FD3A5288F042B6850C66B31F09FE44734EB7990E \
@@ -38,6 +40,6 @@ fi
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    $gnugp_verify_command_name --no-default-keyring --keyring asdf-nodejs.gpg --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key"  && break
+    $gnugp_verify_command_name --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key" && break
   done
 done

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -38,6 +38,6 @@ fi
 
 for key in $KEYS; do
   for server in $SERVERS; do
-    $gnugp_verify_command_name --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key"  && break
+    $gnugp_verify_command_name --no-default-keyring --keyring asdf-nodejs.gpg --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key"  && break
   done
 done

--- a/bin/install
+++ b/bin/install
@@ -186,10 +186,10 @@ download_and_verify_checksums() {
 
     (
       if [ -z "${GNUPGHOME:-}" ] && [ -d "${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
-          export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
+        export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
       fi
 
-      if ! $gnugp_verify_command_name --no-default-keyring --keyring asdf-nodejs.gpg --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
+      if ! $gnugp_verify_command_name --no-default-keyring --keyring "${ASDF_NODEJS_KEYRING}" --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
         # Try default keyring
         if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
           echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
@@ -198,8 +198,8 @@ download_and_verify_checksums() {
       fi
       ## Mitigates: https://github.com/nodejs/node/issues/6821
       local authentic_checksum_file="$tmp_download_dir/authentic_SHASUMS256.txt"
-      $gnugp_verify_command_name --no-default-keyring --keyring asdf-nodejs.gpg --output "${authentic_checksum_file}" --decrypt "$signed_checksum_file" 2>/dev/null || \
-      $gnugp_verify_command_name --output "${authentic_checksum_file}" --decrypt "$signed_checksum_file" 2>/dev/null
+      $gnugp_verify_command_name --no-default-keyring --keyring "${ASDF_NODEJS_KEYRING}" --output "${authentic_checksum_file}" --decrypt "$signed_checksum_file" 2>/dev/null ||
+        $gnugp_verify_command_name --output "${authentic_checksum_file}" --decrypt "$signed_checksum_file" 2>/dev/null
     )
   elif [ "${NODEJS_CHECK_SIGNATURES}" == "strict" ]; then
     echo "$version did not provide signed checksums or support for them has not been implemented and NODEJS_CHECK_SIGNATURES=strict is set. Exiting." >&2

--- a/bin/install
+++ b/bin/install
@@ -189,7 +189,7 @@ download_and_verify_checksums() {
           export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
       fi
 
-      if ! $gnugp_verify_command_name --keyring asdf-nodejs.gpg --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
+      if ! $gnugp_verify_command_name --no-default-keyring --keyring asdf-nodejs.gpg --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
         # Try default keyring
         if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
           echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
@@ -198,6 +198,7 @@ download_and_verify_checksums() {
       fi
       ## Mitigates: https://github.com/nodejs/node/issues/6821
       local authentic_checksum_file="$tmp_download_dir/authentic_SHASUMS256.txt"
+      $gnugp_verify_command_name --no-default-keyring --keyring asdf-nodejs.gpg --output "${authentic_checksum_file}" --decrypt "$signed_checksum_file" 2>/dev/null || \
       $gnugp_verify_command_name --output "${authentic_checksum_file}" --decrypt "$signed_checksum_file" 2>/dev/null
     )
   elif [ "${NODEJS_CHECK_SIGNATURES}" == "strict" ]; then

--- a/bin/install
+++ b/bin/install
@@ -189,9 +189,12 @@ download_and_verify_checksums() {
           export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
       fi
 
-      if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
-        echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
-        exit 1
+      if ! $gnugp_verify_command_name --keyring asdf-nodejs.gpg --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
+        # Try default keyring
+        if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
+          echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
+          exit 1
+        fi
       fi
       ## Mitigates: https://github.com/nodejs/node/issues/6821
       local authentic_checksum_file="$tmp_download_dir/authentic_SHASUMS256.txt"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -3,5 +3,7 @@
 # TODO: Replace with an asdf variable once asdf starts providing the plugin name
 # as a variable
 plugin_name() {
- basename "$(dirname "$(dirname "$0")")"
+  basename "$(dirname "$(dirname "$0")")"
 }
+
+ASDF_NODEJS_KEYRING=asdf-nodejs.gpg


### PR DESCRIPTION
Preparation for fixing #138

Import and use gpg keys in separate keyring

Using separate gpg keyring file:
`~/.gnupg/asdf-nodejs.gpg`
to avoid adding to default keyring