### PR TITLE
Fix `.default-npm-packages` install location

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "$NPM_CONFIG_PREFIX" = "" ] && [ -n "$ASDF_INSTALL_PATH" ]; then
+if [ "${NPM_CONFIG_PREFIX-}" = "" ] && [ -n "$ASDF_INSTALL_PATH" ]; then
   export NPM_CONFIG_PREFIX=$ASDF_INSTALL_PATH/.npm
 fi

--- a/bin/install
+++ b/bin/install
@@ -267,6 +267,7 @@ install_default_npm_packages() {
 
   cat "$default_npm_packages" | while read -r name; do
     echo -ne "\nInstalling \033[33m${name}\033[39m npm package... "
+    source "$(dirname "$0")/exec-env"
     PATH="$ASDF_INSTALL_PATH/bin:$PATH" npm install -g "$name" > /dev/null 2>&1 && rc=$? || rc=$?
     if [[ $rc -eq 0 ]]; then
       echo -e "\033[32mSUCCESS\033[39m"


### PR DESCRIPTION
Source `exec-env` before default global install
to install default packages to same location
as later installs.

Fixes #126 and updating default npm packages.