### PR TITLE
--check to -c for busybox

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -210,11 +210,11 @@ checkShasum ()
 
   if $(command -v sha256sum >/dev/null 2>&1); then
     sha256sum \
-      --check <(grep "\s${archive_file_name}$" "${authentic_checksum_file}")
+      -c <(grep "\s${archive_file_name}$" "${authentic_checksum_file}")
   elif $(command -v shasum >/dev/null 2>&1); then
     shasum \
       -a 256 \
-      --check <(grep "\s${archive_file_name}$" "${authentic_checksum_file}")
+      -c <(grep "\s${archive_file_name}$" "${authentic_checksum_file}")
   else
     echo "sha256sum or shasum is not available for use" >&2
     return 1


### PR DESCRIPTION
when use asdf-node in docker image alpine
```
sha256sum: unrecognized option: check
BusyBox v1.31.1 () multi-call binary.

Usage: sha256sum [-c[sw]] [FILE]...

Print or check SHA256 checksums

        -c      Check sums against list in FILEs
        -s      Don't output anything, status code shows success
        -w      Warn about improperly formatted checksum lines
```