### PR TITLE
Make keyring instructions more flexible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 Import the Node.js release team's OpenPGP keys to main keyring:
 
 ```bash
-bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
+bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
 ```
 
 ## Use


### PR DESCRIPTION
- Honoring `$ASDF_DATA_DIR` lets this command be plug-and-play for [custom installation locations](https://asdf-vm.com/#/core-configuration?id=environment-variables)
- Defaulting to `$HOME/.asdf` keeps it backwards-compatible with previous instructions
- Using `bash -c` with single quotes lets more shells execute the command with env var default and expansion correctly (fish in mind here)