### PR TITLE
Support non-default default-npm-packages location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ request
 express
 ```
 
+You can specify a non-default location of this file by setting a `ASDF_NPM_DEFAULT_PACKAGES_FILE` variable.
+
 ## Temporarily disable reshimming
 
 To avoid a slowdown when installing large packages (see https://github.com/asdf-vm/asdf-nodejs/issues/46), you can `ASDF_SKIP_RESHIM=1 npm i -g <package>` and reshim after installing all packages using `asdf reshim nodejs`.

--- a/bin/install
+++ b/bin/install
@@ -265,7 +265,7 @@ verlte() {
 }
 
 install_default_npm_packages() {
-  local default_npm_packages="${HOME}/.default-npm-packages"
+  local default_npm_packages="${ASDF_NPM_DEFAULT_PACKAGES_FILE:=$HOME/.default-npm-packages}"
 
   if [ ! -f "$default_npm_packages" ]; then return; fi
 


### PR DESCRIPTION
I wanted to place my `default-npm-packages` in a different location to not clutter my HOME directory, but found no way to do so. In this PR people can set their own location using an ENV variable `ASDF_NPM_DEFAULT_PACKAGES_FILE`. This PR is based on https://github.com/danhper/asdf-python/pull/63 and provides a solution for #152.