### PR TITLE
Refactor list all to use the official index.tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Node.js plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 ### MacOS
 * [GNU Core Utils](http://www.gnu.org/software/coreutils/coreutils.html) - `brew install coreutils`
 * [GnuPG](http://www.gnupg.org) - `brew install gpg`
+* awk - any posix compliant implementation (tested on gawk `brew install gawk`)
 
 ### Linux (Debian)
 
@@ -19,6 +20,7 @@ Node.js plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
   dirmngr`
 * [GnuPG](http://www.gnupg.org) - `apt-get install gpg`
 * [curl](https://curl.haxx.se) - `apt-get install curl`
+* awk - any posix compliant implementation (tested on gawk `apt-get install gawk`)
 
 ## Install
 

--- a/bin/install
+++ b/bin/install
@@ -7,85 +7,104 @@ source "$(dirname "$0")/../lib/utils.sh"
 
 NODEJS_CHECK_SIGNATURES="${NODEJS_CHECK_SIGNATURES:-strict}"
 
-ASDF_PLUGIN_NAME=nodejs
 
 install_nodejs() {
   local install_type="$1"
   local version_query="$2"
   local install_path="$3"
   local tmp_download_dir="$4"
+
   local version="$(resolve_version_query "$version_query")"
 
   if [ "$version" != "$version_query" ]; then
-    # install the true version and only symlink it to the alias
-    
-    >&2 echo "Installing alias $version_query as $version"
-    asdf install "$ASDF_PLUGIN_NAME" "$version" \
-      || die "Could not install version $version"
+    install_aliased_version "$version"  "$version_query" "$install_path"
+  else
+    install_canon_version "$1" "$version" "$3" "$4"
+  fi
+}
 
-    if [ -L "$install_path" ]; then
-      rm "$install_path"
+
+install_canon_version() {
+  local install_type="$1"
+  local version="$2"
+  local install_path="$3"
+  local tmp_download_dir="$4"
+
+  ## Do this first as it is fast but could fail.
+  download_and_verify_checksums "$install_type" "$version" "$tmp_download_dir"
+
+  local archive_path
+  archive_path="${tmp_download_dir}/$(get_archive_file_name "$install_type" "$version")"
+  download_file "$(get_download_url "$install_type" "$version")" "${archive_path}" \
+    || die "Binary not found for version $version"
+
+  verify_archive "$tmp_download_dir"
+
+  # running this in a subshell
+  # we don't want to disturb current working dir
+  (
+    if [ "$install_type" != "version" ]; then
+      tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
+      cd "$install_path" || exit 1
+
+      local configure_options
+      configure_options="$(construct_configure_options "$install_path")"
+
+      # shellcheck disable=SC2086
+      ./configure $configure_options || exit 1
+      make
+      make install
+
+      if [ $? -ne 0 ]; then
+        rm -rf "$install_path"
+        exit 1
+      fi
     else
-      rmdir "$install_path"
+      tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
     fi
 
-    >&2 echo "Linking \"$version_query\" to \"$version\""
-    ln -s "$(asdf where "$ASDF_PLUGIN_NAME" "$version")" "$install_path" 
+    mkdir -p "$install_path/.npm/lib/node_modules/.hooks"
+    cp "$(dirname "$(dirname "$0")")"/npm-hooks/* "$install_path/.npm/lib/node_modules/.hooks/"
+    chmod +x "$install_path"/.npm/lib/node_modules/.hooks/*
+  )
+}
+
+
+install_aliased_version() {
+  local version=$1
+  local version_query=$2
+  local install_path=$3
+
+  # install the true version and only symlink it to the alias
+  >&2 echo "Installing alias $version_query as $version"
+  asdf install "$(plugin_name)" "$version" \
+    || die "Could not install version $version"
+
+  if [ -L "$install_path" ]; then
+    rm "$install_path"
   else
-    ## Do this first as it is fast but could fail.
-    download_and_verify_checksums "$install_type" "$version" "$tmp_download_dir"
-
-    local archive_path
-    archive_path="${tmp_download_dir}/$(get_archive_file_name "$install_type" "$version")"
-    download_file "$(get_download_url "$install_type" "$version")" "${archive_path}" \
-      || die "Binary not found for version $version"
-
-    verify_archive "$tmp_download_dir"
-
-    # running this in a subshell
-    # we don't want to disturb current working dir
-    (
-      if [ "$install_type" != "version" ]; then
-        tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
-        cd "$install_path" || exit 1
-
-        local configure_options
-        configure_options="$(construct_configure_options "$install_path")"
-
-        # shellcheck disable=SC2086
-        ./configure $configure_options || exit 1
-        make
-        make install
-
-        if [ $? -ne 0 ]; then
-          rm -rf "$install_path"
-          exit 1
-        fi
-      else
-        tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
-      fi
-
-      mkdir -p "$install_path/.npm/lib/node_modules/.hooks"
-      cp "$(dirname "$(dirname "$0")")"/npm-hooks/* "$install_path/.npm/lib/node_modules/.hooks/"
-      chmod +x "$install_path"/.npm/lib/node_modules/.hooks/*
-    )
+    rmdir "$install_path"
   fi
+
+  >&2 echo "Linking \"$version_query\" to \"$version\""
+  ln -s "$(asdf where "$(plugin_name)" "$version")" "$install_path" 
 }
 
 
 resolve_version_query() {
   local version_query="$1"
-  local aliased="$(
+
+  local canon_version="$(
     # Find the first candidate which the alias match, then print it version
     print_index_tab \
       | filter_version_candidates \
       | awk -F'\t' -v "alias=$version_query" '$1 == alias { print $2; exit }'
   )"
 
-  if ! [ -z "$aliased" ]; then
-    echo "$aliased"
-  else
+  if [ -z "$canon_version" ]; then
     echo "$version_query"
+  else
+    echo "$canon_version"
   fi
 }
 

--- a/bin/install
+++ b/bin/install
@@ -7,26 +7,20 @@ source "$(dirname "$0")/../lib/utils.sh"
 
 NODEJS_CHECK_SIGNATURES="${NODEJS_CHECK_SIGNATURES:-strict}"
 
-# When in China, set $NODEJS_ORG_MIRROR:
-# export NODEJS_ORG_MIRROR=https://npm.taobao.org/mirrors/node/
-NODEJS_ORG_MIRROR="${NODEJS_ORG_MIRROR:-https://nodejs.org/dist/}"
-if [ ${NODEJS_ORG_MIRROR: -1} != / ]
-then
-  NODEJS_ORG_MIRROR=$NODEJS_ORG_MIRROR/
-fi
-
 install_nodejs() {
   local install_type="$1"
-  local version="$2"
+  local version_query="$2"
   local install_path="$3"
   local tmp_download_dir="$4"
+  local version="$(resolve_version_query "$version_query")"
 
   ## Do this first as it is fast but could fail.
   download_and_verify_checksums "$install_type" "$version" "$tmp_download_dir"
 
   local archive_path
   archive_path="${tmp_download_dir}/$(get_archive_file_name "$install_type" "$version")"
-  download_file "$(get_download_url "$install_type" "$version")" "${archive_path}"
+  download_file "$(get_download_url "$install_type" "$version")" "${archive_path}" \
+    || die "Binary not found for version $version"
 
   verify_archive "$tmp_download_dir"
 
@@ -59,6 +53,21 @@ install_nodejs() {
   )
 }
 
+resolve_version_query() {
+  local version_query="$1"
+  local aliased="$(
+    print_index_tab \
+      | filter_version_candidates \
+      | awk -F'\t' -v "al=$version_query" '$1 == al { print $2; exit }'
+  )"
+
+  if ! [ -z "$aliased" ]; then
+    >&2 echo "Installing alias $version_query as $aliased"
+    echo "$aliased"
+  else
+    echo "$version_query"
+  fi
+}
 
 construct_configure_options() {
   local install_path="$1"
@@ -102,8 +111,7 @@ download_file() {
   STATUSCODE=$(curl --write-out "%{http_code}" -Lo "$download_path" -C - "$download_url")
 
   if test $STATUSCODE -eq 404; then
-    echo "Binaries were not found. Full version must be specified, not just major version."
-    exit 1
+    return 1
   fi
 }
 
@@ -175,7 +183,9 @@ download_and_verify_checksums() {
         return 0
       fi
     fi
-    download_file "${signed_checksum_download_url}" "$signed_checksum_file"
+
+    download_file "${signed_checksum_download_url}" "$signed_checksum_file" \
+      || die "Checksum not found for version $version"
 
     local gnugp_verify_command_name
     gnugp_verify_command_name="$(command -v gpg gpg2 | head -n 1 || :)"

--- a/bin/install
+++ b/bin/install
@@ -53,12 +53,14 @@ install_nodejs() {
   )
 }
 
+
 resolve_version_query() {
   local version_query="$1"
   local aliased="$(
+    # Find the first candidate which the alias match, then print it version
     print_index_tab \
       | filter_version_candidates \
-      | awk -F'\t' -v "al=$version_query" '$1 == al { print $2; exit }'
+      | awk -F'\t' -v "alias=$version_query" '$1 == alias { print $2; exit }'
   )"
 
   if ! [ -z "$aliased" ]; then
@@ -68,6 +70,7 @@ resolve_version_query() {
     echo "$version_query"
   fi
 }
+
 
 construct_configure_options() {
   local install_path="$1"

--- a/bin/install
+++ b/bin/install
@@ -7,6 +7,8 @@ source "$(dirname "$0")/../lib/utils.sh"
 
 NODEJS_CHECK_SIGNATURES="${NODEJS_CHECK_SIGNATURES:-strict}"
 
+ASDF_PLUGIN_NAME=nodejs
+
 install_nodejs() {
   local install_type="$1"
   local version_query="$2"
@@ -14,43 +16,60 @@ install_nodejs() {
   local tmp_download_dir="$4"
   local version="$(resolve_version_query "$version_query")"
 
-  ## Do this first as it is fast but could fail.
-  download_and_verify_checksums "$install_type" "$version" "$tmp_download_dir"
+  if [ "$version" != "$version_query" ]; then
+    # install the true version and only symlink it to the alias
+    
+    >&2 echo "Installing alias $version_query as $version"
+    asdf install "$ASDF_PLUGIN_NAME" "$version" \
+      || die "Could not install version $version"
 
-  local archive_path
-  archive_path="${tmp_download_dir}/$(get_archive_file_name "$install_type" "$version")"
-  download_file "$(get_download_url "$install_type" "$version")" "${archive_path}" \
-    || die "Binary not found for version $version"
-
-  verify_archive "$tmp_download_dir"
-
-  # running this in a subshell
-  # we don't want to disturb current working dir
-  (
-    if [ "$install_type" != "version" ]; then
-      tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
-      cd "$install_path" || exit 1
-
-      local configure_options
-      configure_options="$(construct_configure_options "$install_path")"
-
-      # shellcheck disable=SC2086
-      ./configure $configure_options || exit 1
-      make
-      make install
-
-      if [ $? -ne 0 ]; then
-        rm -rf "$install_path"
-        exit 1
-      fi
+    if [ -L "$install_path" ]; then
+      rm "$install_path"
     else
-      tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
+      rmdir "$install_path"
     fi
 
-    mkdir -p "$install_path/.npm/lib/node_modules/.hooks"
-    cp "$(dirname "$(dirname "$0")")"/npm-hooks/* "$install_path/.npm/lib/node_modules/.hooks/"
-    chmod +x "$install_path"/.npm/lib/node_modules/.hooks/*
-  )
+    >&2 echo "Linking \"$version_query\" to \"$version\""
+    ln -s "$(asdf where "$ASDF_PLUGIN_NAME" "$version")" "$install_path" 
+  else
+    ## Do this first as it is fast but could fail.
+    download_and_verify_checksums "$install_type" "$version" "$tmp_download_dir"
+
+    local archive_path
+    archive_path="${tmp_download_dir}/$(get_archive_file_name "$install_type" "$version")"
+    download_file "$(get_download_url "$install_type" "$version")" "${archive_path}" \
+      || die "Binary not found for version $version"
+
+    verify_archive "$tmp_download_dir"
+
+    # running this in a subshell
+    # we don't want to disturb current working dir
+    (
+      if [ "$install_type" != "version" ]; then
+        tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
+        cd "$install_path" || exit 1
+
+        local configure_options
+        configure_options="$(construct_configure_options "$install_path")"
+
+        # shellcheck disable=SC2086
+        ./configure $configure_options || exit 1
+        make
+        make install
+
+        if [ $? -ne 0 ]; then
+          rm -rf "$install_path"
+          exit 1
+        fi
+      else
+        tar zxf "$archive_path" -C "$install_path" --strip-components=1 || exit 1
+      fi
+
+      mkdir -p "$install_path/.npm/lib/node_modules/.hooks"
+      cp "$(dirname "$(dirname "$0")")"/npm-hooks/* "$install_path/.npm/lib/node_modules/.hooks/"
+      chmod +x "$install_path"/.npm/lib/node_modules/.hooks/*
+    )
+  fi
 }
 
 
@@ -64,7 +83,6 @@ resolve_version_query() {
   )"
 
   if ! [ -z "$aliased" ]; then
-    >&2 echo "Installing alias $version_query as $aliased"
     echo "$aliased"
   else
     echo "$version_query"

--- a/bin/list-all
+++ b/bin/list-all
@@ -7,5 +7,6 @@ source "$(dirname "$0")/../lib/utils.sh"
 
 # Print
 echo $(
+  # Only print the first column of candidates
   print_index_tab | filter_version_candidates | awk -F'\t' '{ print $1 }' | tac
 )

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
+set -o nounset -o pipefail -o errexit
+
+# shellcheck source=../lib/utils.sh
+source "$(dirname "$0")/../lib/utils.sh"
+
 echo $(
-  curl --silent https://semver.io/node/versions \
-  | grep -E -v '^0\.([0-9])\.'
+  print_index_tab | filter_candidates_versions | awk -F'\t' '{ print $1 }' | tac
 )

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,6 +5,7 @@ set -o nounset -o pipefail -o errexit
 # shellcheck source=../lib/utils.sh
 source "$(dirname "$0")/../lib/utils.sh"
 
+# Print
 echo $(
-  print_index_tab | filter_candidates_versions | awk -F'\t' '{ print $1 }' | tac
+  print_index_tab | filter_version_candidates | awk -F'\t' '{ print $1 }' | tac
 )

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -64,7 +64,7 @@ filter_version_candidates() {
           print "lts\t" vers
         }
 
-        lts_alias = "lts/" tolower(record["lts"])
+        lts_alias = "lts-" tolower(record["lts"])
         if (!(lts_alias in aliases)) {
           aliases[lts_alias] = vers
           print lts_alias "\t" vers

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -8,6 +8,8 @@ then
   NODEJS_ORG_MIRROR=$NODEJS_ORG_MIRROR/
 fi
 
+ASDF_NODEJS_KEYRING=asdf-nodejs.gpg
+
 # TODO: Replace with an asdf variable once asdf starts providing the plugin name
 # as a variable
 plugin_name() {
@@ -18,8 +20,6 @@ die() {
   >&2 echo "$@"
   exit 1
 }
-
-ASDF_NODEJS_KEYRING=asdf-nodejs.gpg
 
 # TODO: implement a cache for the tab. The api supports If-None-Match and
 # If-Modified-Since HTTP headers

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,9 +1,77 @@
 # Helper functions
 
+# When in China, set $NODEJS_ORG_MIRROR:
+# export NODEJS_ORG_MIRROR=https://npm.taobao.org/mirrors/node/
+NODEJS_ORG_MIRROR="${NODEJS_ORG_MIRROR:-https://nodejs.org/dist/}"
+if [ ${NODEJS_ORG_MIRROR: -1} != / ]
+then
+  NODEJS_ORG_MIRROR=$NODEJS_ORG_MIRROR/
+fi
+
 # TODO: Replace with an asdf variable once asdf starts providing the plugin name
 # as a variable
 plugin_name() {
   basename "$(dirname "$(dirname "$0")")"
 }
 
+die() {
+  >&2 echo "$@"
+  exit 1
+}
+
 ASDF_NODEJS_KEYRING=asdf-nodejs.gpg
+
+# TODO: implement a cache for the tab. The api supports If-None-Match and
+# If-Modified-Since HTTP headers
+print_index_tab() {
+  curl --silent "${NODEJS_ORG_MIRROR}index.tab"
+}
+
+# Print all alias and correspondent versions in the format "$alias\t$version"
+# Also prints versions as a alias of itself. Eg: "v10.0.0	v10.0.0"
+filter_version_candidates() {
+  awk -F'\t' '
+    # First line is the headers for the columns
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        cols[cols_size++] = $i
+      }
+
+      # Skip first line because we got all the information already
+      next
+    }
+
+    # Add a global variable `record` with the current line version
+    # using the headers as fields
+    {
+      for (i = 1; i < NF; i++) {
+        record[cols[i - 1]] = $i
+      }
+    }
+
+    {
+      # Version without the `v` prefix
+      vers = substr(record["version"], 2) 
+
+      # We need to check if the lts alias is in a variable because multiple versions
+      # have the same alias, we want to print only the most recent
+      if (record["lts"] != "-") {
+
+        # Check if lts is already printed, if not print it as version candidate and
+        # put it at the aliases map
+        if (!("lts" in aliases)) {
+          aliases["lts"] = vers
+          print "lts\t" vers
+        }
+
+        lts_alias = "lts/" tolower(record["lts"])
+        if (!(lts_alias in aliases)) {
+          aliases[lts_alias] = vers
+          print lts_alias "\t" vers
+        }
+      }
+
+      print vers "\t" vers
+    }
+  '
+}


### PR DESCRIPTION
I refactored the list-all to use [the official](https://github.com/nodejs/nodejs-dist-indexer) npm [index.tab](https://nodejs.org/dist/index.tab). It process the table using awk and makes trivial to implement aliases for lts and lts/alias as the tab already gives us the information.

I also rewrite some message errors for the new aliases, unified some common (starting in this pr) behavior in the utils.sh and added the awk dependency to the README.

I'm open to review and discuss the code

EDIT: I forgot to mention, but [the previous mechanism for resolving the versions](https://github.com/heroku/semver.io#readme) is now marked as read only and has a uncertain future, the official tab and json files are already being used by other similiar tools ([I checked n](https://github.com/tj/n/blob/cbc01f3ae06c90ff686cbeeed0c95005314a24c8/bin/n#L1051) only)

closes #134