### PR TITLE
Suggest updating plugin upon failure

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -192,7 +192,7 @@ download_and_verify_checksums() {
       if ! $gnugp_verify_command_name --no-default-keyring --keyring "${ASDF_NODEJS_KEYRING}" --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
         # Try default keyring
         if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
-          echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. Also, make sure the plugin is up-to-date by running \`asdf plugin update nodejs\`. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
+          echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. Also, make sure the plugin is up-to-date by running \`asdf plugin update $(plugin_name)\`. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
           exit 1
         fi
       fi

--- a/bin/install
+++ b/bin/install
@@ -192,7 +192,7 @@ download_and_verify_checksums() {
       if ! $gnugp_verify_command_name --no-default-keyring --keyring "${ASDF_NODEJS_KEYRING}" --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
         # Try default keyring
         if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
-          echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
+          echo "Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. Also, make sure the plugin is up-to-date by running \`asdf plugin update nodejs\`. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting." >&2
           exit 1
         fi
       fi


### PR DESCRIPTION
## Background
I ran into an issue today where I couldn't run this command without an error:

```console
 asdf install nodejs 14.15.0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3838    0  3838    0     0  18631      0 --:--:-- --:--:-- --:--:-- 18631
Authenticity of checksum file can not be assured! Please be sure to check the README of asdf-nodejs in case you did not yet import the needed PGP keys. If you already did that then that is the point to become SUSPICIOUS! There must be a reason why this is failing. If you are installing an older NodeJS version you might need to import OpenPGP keys of previous release managers. Exiting.
```

So, I went to the README and ran this command to try to resolve the problem:

```console
bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
```

However, I still ran into the same problem even after doing that. To fix the problem, I needed to update the plugin (for an updated version of `import-release-team-keyring`) and re-run the script. Then everything worked.

## Update

This PR suggests to the user to also update their local plugin before being too worried that the release is suspicious. I tested this out locally.