### PR TITLE
Add support to parsing lts/* aliases in legacy config files

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 echo $(
-  sed '1 s/^v//' "$1"
+  sed '1 s/^v//; s/\//-/; s/-\*$//' "$1"
 )

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 echo $(
-  sed '1 s/^v//; s/^lts\//lts-/; s/^lts-\*$//' "$1"
+  sed '1 s/^v//; s/^lts\//lts-/; s/^lts-\*$/lts/' "$1"
 )

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 echo $(
-  sed '1 s/^v//; s/\//-/; s/-\*$//' "$1"
+  sed '1 s/^v//; s/^lts\//lts-/; s/^lts-\*$//' "$1"
 )


### PR DESCRIPTION
Partially solves #193, we still cannot run `asdf install nodejs "lts/*"`, but now it translates the .nvmrc version correctly from `lts/codename` to `lts-codename` and `lts/*` to `lts`