### PR TITLE
improve legacy file version parsing

### DIFF
--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
-echo $(
-  sed '1 s/^v//' "$1"
-)
+
+version=$(sed '1 s/^v//' "$1")
+
+if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo $version
+elif [[ "$version" = "node" ]]; then
+  echo $(
+    asdf list nodejs | tail -n1
+  )
+else
+  final_version=$(
+    asdf list nodejs | grep "^\s*$version" | tail -n1
+  )
+  [[ ! -z "$final_version" ]] && echo $final_version || echo $version
+fi


### PR DESCRIPTION
This adds support for "node" and partial version numbers (e.g. "14", "14.15"). It doesn't add LTS but there's another PR for that (#194). If both are acceptable I'm sure they can be reconciled.