### PR TITLE
Add check to see if key already exists locally before querying keyservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,7 @@ Install the plugin:
 asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 ```
 
-Import the Node.js release team's OpenPGP keys to main keyring:
-
-```bash
-bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
-```
-
-If you are trying to install a previous release and facing any issue about verification, import the Node.js previous release team's OpenPGP keys to main keyring:
+The plugin now automatically imports the NodeJS release team's OpenPGP keys. If you are trying to install a previous release and facing any issue about verification, import the Node.js previous release team's OpenPGP keys to main keyring:
 
 ```bash
 bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-previous-release-team-keyring'

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -39,7 +39,9 @@ if [ -z "${gnugp_verify_command_name}" ]; then
 fi
 
 for key in $KEYS; do
-  for server in $SERVERS; do
-    $gnugp_verify_command_name --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key" && break
-  done
+    for server in $SERVERS; do
+      $gnugp_verify_command_name --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} -k $key -with-colons > /dev/null 2>&1 || \
+      $gnugp_verify_command_name --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key" && break
+    done
+#  fi
 done

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -40,7 +40,7 @@ fi
 
 for key in $KEYS; do
     for server in $SERVERS; do
-      $gnugp_verify_command_name --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} -k $key -with-colons > /dev/null 2>&1 || \
+      $gnugp_verify_command_name --with-colons --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} -k $key > /dev/null 2>&1 || \
       $gnugp_verify_command_name --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key" && break
     done
 #  fi

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -43,5 +43,4 @@ for key in $KEYS; do
       $gnugp_verify_command_name --with-colons --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} -k $key > /dev/null 2>&1 || \
       $gnugp_verify_command_name --no-default-keyring --keyring ${ASDF_NODEJS_KEYRING} --no-tty --keyserver "hkp://$server" $OPTIONS --display-charset utf-8 --recv-keys "$key" && break
     done
-#  fi
 done

--- a/bin/install
+++ b/bin/install
@@ -242,7 +242,7 @@ download_and_verify_checksums() {
       fi
 
       # Automatically add needed PGP keys
-      source "$(dirname "$0")/import-release-team-keyring"
+      "$(dirname "$0")/import-release-team-keyring"
 
       if ! $gnugp_verify_command_name --no-default-keyring --keyring "${ASDF_NODEJS_KEYRING}" --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
         # Try default keyring

--- a/bin/install
+++ b/bin/install
@@ -241,6 +241,9 @@ download_and_verify_checksums() {
         export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
       fi
 
+      # Automatically add needed PGP keys
+      source "$(dirname "$0")/import-release-team-keyring"
+
       if ! $gnugp_verify_command_name --no-default-keyring --keyring "${ASDF_NODEJS_KEYRING}" --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then
         # Try default keyring
         if ! $gnugp_verify_command_name --display-charset utf-8 --verify "$signed_checksum_file" 2>/dev/null; then


### PR DESCRIPTION
Addresses issue #208. Checks to see if the key exists in the keyring. If the check is successful, it bypasses the remote call. This *vastly* reduces the time needed to execute this script on subsequent runs (which is helpful when you're using something like ansible to manage asdf/plugin configs).