### PR TITLE
Replace Bash 4+ lowercase logic with POSIX alternative using 'tr'

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -43,7 +43,7 @@ filter_version_candidates() {
     # Version without `v` prefix
     local version="${fields[0]#v}"
     # Lowercase lts codename, `-` if not a lts version
-    local lts_codename="${fields[9],,}"
+    local lts_codename=$(echo "${fields[9]}" | tr '[:upper:]' '[:lower:]')
 
     if [ "$lts_codename" != - ]; then
       # No lts read yet, so this must be the more recent


### PR DESCRIPTION
Closes #206.

Currently, lowercase logic is using a feature specific to Bash 4+.
https://github.com/asdf-vm/asdf-nodejs/blob/5a46614ec24177146541543d3ec6327e136ae80f/lib/utils.sh#L46

This is not part of [POSIX Specification for parameter expansion](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02)

PR uses [tr](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tr.html) as low-dependency alternative.