### PR TITLE
install: Try to use ASDF_DATA_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The `bash` script mentioned in [the installation instructions](#install) (`impor
 To use a dedicated keyring, prepare the dedicated keyring and set it as the default keyring in the current shell:
 
 ```bash
-export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs" && mkdir -p "$GNUPGHOME" && chmod 0700 "$GNUPGHOME"
+export GNUPGHOME="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs" && mkdir -p "$GNUPGHOME" && chmod 0700 "$GNUPGHOME"
 
 # Imports Node.js release team's OpenPGP keys to the keyring
 bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ To avoid a slowdown when installing large packages (see https://github.com/asdf-
 
 The `bash` script mentioned in [the installation instructions](#install) (`import-release-team-keyring`) imports the OpenPGP public keys in your main OpenPGP keyring. However, you can also use a dedicated keyring in order to mitigate [this issue](https://github.com/nodejs/node/issues/9859).
 
-To use a dedicated keyring, prepare the dedicated keyring and set it as the default keyring in the current shell:
+To use a dedicated keyring, prepare the dedicated keyring directory and set it as the default keyring in the current shell:
 
 ```bash
-export GNUPGHOME="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs" && mkdir -p "$GNUPGHOME" && chmod 0700 "$GNUPGHOME"
+export ASDF_NODEJS_KEYRING_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs" && mkdir -p "$ASDF_NODEJS_KEYRING_DIR" && chmod 0700 "$ASDF_NODEJS_KEYRING_DIR"
 
 # Imports Node.js release team's OpenPGP keys to the keyring
 bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
@@ -86,11 +86,13 @@ bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
 Again, if you used `brew` to manage the `asdf` installation use the following bash commands:
 
 ```bash
-export GNUPGHOME="bash /usr/local/opt/asdf/keyrings/nodejs" && mkdir -p "$GNUPGHOME" && chmod 0700 "$GNUPGHOME"
+export ASDF_NODEJS_KEYRING_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs" && mkdir -p "$ASDF_NODEJS_KEYRING_DIR" && chmod 0700 "$ASDF_NODEJS_KEYRING_DIR"
 
 # Imports Node.js release team's OpenPGP keys to the keyring
 bash /usr/local/opt/asdf/plugins/nodejs/bin/import-release-team-keyring
 ```
+
+It is of course possible to override the directory by setting `$ASDF_NODEJS_KEYRING_DIR` as desired; however, that must be set every time any attempt to install NodeJS is made, instead of just when the initial keyring import is done.
 
 #### Related notes
 

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -4,6 +4,10 @@ set -o nounset -o pipefail -o errexit
 
 source "$(dirname "$0")/../lib/utils.sh"
 
+if [ -n "${ASDF_NODEJS_KEYRING_DIR:-}" ]; then
+  export GNUPGHOME="$ASDF_NODEJS_KEYRING_DIR"
+fi
+
 ## Keys from https://github.com/nodejs/node/#release-keys
 KEYS="4ED778F539E3634C779C87C6D7062848A1AB005C \
       94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \

--- a/bin/install
+++ b/bin/install
@@ -237,8 +237,12 @@ download_and_verify_checksums() {
     fi
 
     (
-      if [ -z "${GNUPGHOME:-}" ] && [ -d "${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
-        export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
+      if [ -z "${GNUPGHOME:-}" ]; then
+        if [ -d "${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
+          export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
+        elif [ -d "${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
+          export GNUPGHOME="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs"
+        fi
       fi
 
       # Automatically add needed PGP keys

--- a/bin/install
+++ b/bin/install
@@ -238,10 +238,15 @@ download_and_verify_checksums() {
 
     (
       if [ -z "${GNUPGHOME:-}" ]; then
-        if [ -d "${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
-          export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
-        elif [ -d "${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
-          export GNUPGHOME="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs"
+        if [ -n "${ASDF_NODEJS_KEYRING_DIR:-}" ]; then
+          export GNUPGHOME="$ASDF_NODEJS_KEYRING_DIR"
+        else
+          for dir in "${ASDF_DATA_DIR:-$HOME/.asdf}" "${ASDF_DIR:-$HOME/.asdf}" ;do
+            if [ -d "$dir/keyrings/nodejs" ]; then
+              export GNUPGHOME="$dir/keyrings/nodejs"
+              break
+            fi
+          done
         fi
       fi
 


### PR DESCRIPTION
This allows the GPG keyrings to be installed into `${ASDF_DATA_DIR}` rather than `${ASDF_DIR}`; this is useful if asdf itself may be replaced wholesale (e.g. by a package manager).  Semantically, it also makes more sense to put the keyring into the data directory, as it is not part of the core asdf application.

Fixes #205.