### PR TITLE
Using ASDF_DATA_DIR instead of ASDF_DIR

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -237,8 +237,8 @@ download_and_verify_checksums() {
     fi
 
     (
-      if [ -z "${GNUPGHOME:-}" ] && [ -d "${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
-        export GNUPGHOME="${ASDF_DIR:-$HOME/.asdf}/keyrings/nodejs"
+      if [ -z "${GNUPGHOME:-}" ] && [ -d "${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs" ]; then
+        export GNUPGHOME="${ASDF_DATA_DIR:-$HOME/.asdf}/keyrings/nodejs"
       fi
 
       # Automatically add needed PGP keys


### PR DESCRIPTION
As far as I know `$ASDF_DIR` refers to the executable directory and not the path where shims and other stuff are in. 
Could it be referring to `$ASDF_DATA_DIR`?