### PR TITLE
Fix tac on OSX if coreutils are linked in path

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # simulate tac on macOS
-if [[ $(uname -s) = Darwin ]]; then
+if [[ $(uname -s) = Darwin ]] && ! command -v tac &>/dev/null; then
   tac() {
     tail -r "$@"
   }

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # simulate tac on macOS
-if [[ $(uname -s) = Darwin ]] && ! command -v tac &>/dev/null; then
+if ! command -v tac &>/dev/null; then
   tac() {
-    tail -r "$@"
+    cat -n "$@" | sort -nrk1 | cut -f2-
   }
 fi
 


### PR DESCRIPTION
One of recent commits (6667b3165fa86e9471c992a94a47f431b6880922) dealed with `tac` not being present on `PATH` on OSX systems.
The problem is that `coreutils` is widely installed (via `brew`) on OSX systems by developers and it in fact includes missing `tac` utility! But its `tail` is missing `-r` flag:
```
~/c/asdf-nodejs (fix/osx-tac-coreutils-in-path) $ asdf list-all nodejs
tail: invalid option -- 'r'
Try 'tail --help' for more information.
```

This PR adds a check before implementing tac over `tail` to see if tac is present.