### PR TITLE
feat: Implement index tab cache

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -87,7 +87,7 @@ install_aliased_version() {
   fi
 
   >&2 echo "Linking \"$version_query\" to \"$version\""
-  ln -s "$(asdf where "$(plugin_name)" "$version")" "$install_path" 
+  ln -s "$(asdf where "$(plugin_name)" "$version")" "$install_path"
 }
 
 
@@ -97,7 +97,6 @@ resolve_version_query() {
   local canon_version="$(
     # Find the first candidate which the alias match, then print it version
     print_index_tab \
-      | filter_version_candidates \
       | awk -F'\t' -v "alias=$version_query" '$1 == alias { print $2; exit }'
   )"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -15,5 +15,5 @@ source "$(dirname "$0")/../lib/utils.sh"
 # Print
 echo $(
   # Only print the first column of candidates
-  print_index_tab | filter_version_candidates | cut -f1 | tac
+  print_index_tab | cut -f1 | tac
 )

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -75,7 +75,7 @@ print_index_tab(){
   if [ -z "$index" ]; then
     cat "$index_file"
   else
-    cat "$temp_headers_file" | awk '/^etag: /{print(substr($0, 7))}' > "$etag_file"
+    cat "$temp_headers_file" | awk 'tolower($1) == "etag:" { print $2 }' > "$etag_file"
     echo "$index" | filter_version_candidates | tee "$index_file"
   fi
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -58,7 +58,7 @@ filter_version_candidates() {
 }
 
 versions_cache_dir="${ASDF_DATA_DIR:-${ASDF_HOME:-$HOME/.asdf}}/tmp/$(plugin_name)/cache"
-mkdir -p $versions_cache_dir
+mkdir -p "$versions_cache_dir"
 
 etag_file="$versions_cache_dir/etag"
 index_file="$versions_cache_dir/index"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -57,7 +57,7 @@ filter_version_candidates() {
   done
 }
 
-versions_cache_dir=~/.asdf/tmp/$(plugin_name)/cache
+versions_cache_dir="${ASDF_DATA_DIR:-${ASDF_HOME:-$HOME/.asdf}}/tmp/$(plugin_name)/cache"
 mkdir -p $versions_cache_dir
 
 etag_file="$versions_cache_dir/etag"


### PR DESCRIPTION
This plugins performance suffers when it comes to list-all and tab completion for available versions.
This PR resolves existing TODO by implementing cache for index tab based on returned headers for index tab (`max-age` and `age`).
It uses the fact that `filter_version_candidates` is internal function and itself and therefore already filtered list can be cached.

With this patch cached version is used and no network connection is required to list versions.