### PR TITLE
Fix prefix being override unecessarily

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-if [ "${NPM_CONFIG_PREFIX-}" = "" ] && [ -n "$ASDF_INSTALL_PATH" ]; then
-  export NPM_CONFIG_PREFIX=$ASDF_INSTALL_PATH/.npm
-fi

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo ".npm/bin bin"


### PR DESCRIPTION
Node already resolves the correct prefix based on the binary location, the problem with overriding it is that the prefix can be customized to a different location in the .npmrc global config file. We already allow prefix customization by setting the variable itself

Closes #306
Closes #245
Closes #22
Closes #157