### PR TITLE
Remove broken keyservers

### DIFF
--- a/bin/import-previous-release-team-keyring
+++ b/bin/import-previous-release-team-keyring
@@ -13,10 +13,7 @@ KEYS="9554F04D7259F04124DE6B476D5A82AC7E37093B \
       7937DFD2AB06298B2293C3187D33FF9D0246406D \
       1C050899334244A8AF75E53792EF661D867B9DFA"
 
-SERVERS="ha.pool.sks-keyservers.net
-         p80.pool.sks-keyservers.net:80 \
-         ipv4.pool.sks-keyservers.net \
-         keyserver.ubuntu.com
+SERVERS="keyserver.ubuntu.com
          keyserver.ubuntu.com:80 \
          pgp.mit.edu
          pgp.mit.edu:80"

--- a/bin/import-release-team-keyring
+++ b/bin/import-release-team-keyring
@@ -17,10 +17,7 @@ KEYS="4ED778F539E3634C779C87C6D7062848A1AB005C \
       108F52B48DB57BB0CC439B2997B01419BD92F80A \
       B9E2F5981AA6E0CD28160D9FF13993A75599653C"
 
-SERVERS="ha.pool.sks-keyservers.net
-         p80.pool.sks-keyservers.net:80 \
-         ipv4.pool.sks-keyservers.net \
-         keyserver.ubuntu.com
+SERVERS="keyserver.ubuntu.com
          keyserver.ubuntu.com:80 \
          pgp.mit.edu
          pgp.mit.edu:80"


### PR DESCRIPTION
The following key servers do not work anymore, causing installation issues:
```
ha.pool.sks-keyservers.net
         p80.pool.sks-keyservers.net:80 \
         ipv4.pool.sks-keyservers.net
```

Remove them.

```
This service is deprecated. This means it is no longer maintained, and new HKPS certificates will not be issued. Service reliability should not be expected.

Update 2021-06-21: Due to even more GDPR takedown requests, the DNS records for the pool will no longer be provided at all.

```
https://sks-keyservers.net/overview-of-pools.php