### PR TITLE
Fix Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Node.js plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 After installing [asdf](https://github.com/asdf-vm/asdf), install the plugin by running:
 
 ```bash
-asdf plugin add https://github.com/asdf-vm/asdf-nodejs.git 
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git 
 ```
 
 ## Use


### PR DESCRIPTION
The `<name>` param of `asdf plugin add <name> [<git-url>]` got lost, resulting in:

```
$ asdf plugin add https://github.com/asdf-vm/asdf-nodejs.git
plugin https://github.com/asdf-vm/asdf-nodejs.git not found in repository
```