### PR TITLE
Fix print_index_tab to ensure cache is written

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -94,8 +94,7 @@ resolve_version_query() {
   local canon_version="$(
     # Find the first candidate which the alias match, then print it version
     print_index_tab \
-      | awk -F'\t' -v "alias=$version_query" '$1 == alias { print $2 }' \
-      | head -n 1
+      | awk -F'\t' -v "alias=$version_query" '$1 == alias { print $2; exit }'
   )"
 
   if [ -z "$canon_version" ]; then

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -80,7 +80,8 @@ print_index_tab(){
     cat "$index_file"
   else
     cat "$temp_headers_file" | awk 'tolower($1) == "etag:" { print $2 }' > "$etag_file"
-    echo "$index" | filter_version_candidates | tee "$index_file"
+    echo "$index" | filter_version_candidates > "$index_file"
+    cat "$index_file"
   fi
 
   rm "$temp_headers_file"


### PR DESCRIPTION
Prior to this change the `tee` call was susceptible to its output being closed causing the pipeline to exit with `SIGPIPE`. This change replaces `tee` with two parts. 

1. Write directly to `"$index_file"`
2. `cat` the contents of `"$index_file"` to `stdout`. 

This way, if the receiving side of the pipe exits, `cat` will exit without impacting the index cache

Reimplements #264
Refixes #263 