### PR TITLE
Remove dependency on bc in favor of a pure bash implementation

### DIFF
--- a/lib/commands/command-nodebuild.bash
+++ b/lib/commands/command-nodebuild.bash
@@ -4,10 +4,8 @@ set -eu -o pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../utils.sh"
 
-DEFAULT_CONCURRENCY=$(bc <<< "scale=0; (${ASDF_CONCURRENCY-1} + 1) / 2")
-
 : "${ASDF_NODEJS_NODEBUILD_HOME=$ASDF_NODEJS_PLUGIN_DIR/.node-build}"
-: "${ASDF_NODEJS_CONCURRENCY=$DEFAULT_CONCURRENCY}"
+: "${ASDF_NODEJS_CONCURRENCY=$((${ASDF_CONCURRENCY:-1} + 1 / 2))}"
 
 # node-build environment variables being overriden by asdf-nodejs
 export NODE_BUILD_CACHE_PATH="${NODE_BUILD_CACHE_PATH:-$ASDF_NODEJS_CACHE_DIR/node-build}"


### PR DESCRIPTION
As mentioned in #272, `bc` is not present in some bare/slim distributions. This PR refactors the usage of bc into a pure bash implementation