### PR TITLE
Change fallbacks to ASDF_DATA_DIR to not include ASDF_DIR

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -17,8 +17,11 @@ plugin_name() {
   printf "%s\n" "$ASDF_NODEJS_PLUGIN_NAME"
 }
 
-export ASDF_NODEJS_CACHE_DIR="${ASDF_DATA_DIR:-${ASDF_DIR:-$HOME/.asdf}}/tmp/$ASDF_NODEJS_PLUGIN_NAME/cache"
-export ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
+asdf_data_dir() {
+  printf "%s\n" "${ASDF_DATA_DIR:-$HOME/.asdf}"
+}
+
+export ASDF_NODEJS_CACHE_DIR="$(asdf_data_dir)/tmp/$ASDF_NODEJS_PLUGIN_NAME/cache"
 
 # Colors
 colored() {

--- a/shims/npm
+++ b/shims/npm
@@ -11,7 +11,7 @@ plugin_name=$(basename "$(dirname "$this_dir")")
 
 this_dir=$(cd "$this_dir" && pwd -P) # Normalizes the directory
 
-asdf_data_dir=$(cd "${ASDF_DATA_DIR:-${ASDF_HOME:-$HOME/.asdf}}" && pwd -P)
+asdf_data_dir=$(cd "${ASDF_DATA_DIR:-$HOME/.asdf}" && pwd -P)
 asdf_shims_dir="$asdf_data_dir/shims"
 
 plugin_dir="$asdf_data_dir/plugins/$plugin_name"


### PR DESCRIPTION
As talked about in #277, we shouldn't fallback `ASDF_DATA_DIR` to `ASDF_DIR`. asdf can be installed system-wide while the plugins, installs, and tmp data should be managed at user level

closes #277