### PR TITLE
Add option for forcing compilation when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ When compiling a version from source, you are going to need to install [all requ
 
 `node-build` already has a [handful of settings](https://github.com/nodenv/node-build#custom-build-configuration), in additional to that `asdf-nodejs` has a few extra configuration variables:
 
+- `ASDF_NODEJS_VERBOSE_INSTALL`: Enables verbose output for downloading and building. Any value different from empty is treated as enabled.
+- `ASDF_NODEJS_FORCE_COMPILE`: Forces compilation from source instead of preferring pre-compiled binaries
 - `ASDF_NODEJS_NODEBUILD_HOME`: Home for the node-build installation, defaults to `$ASDF_DIR/plugins/nodejs/.node-build`, you can install it in another place or share it with your system
 - `ASDF_NODEJS_NODEBUILD`: Path to the node-build executable, defaults to `$NODE_BUILD_MIRROR_URL/bin/node-build`
 - `ASDF_NODEJS_CONCURRENCY`: How many jobs should be used in compilation. Defaults to half the computer cores
-- `ASDF_NODEJS_VERBOSE_INSTALL`: Enables verbose output for downloading and building. Any value different from empty is treated as enabled.
 - `NODEJS_ORG_MIRROR`: (Legacy) overrides the default mirror used for downloading the distibutions, alternative to the `NODE_BUILD_MIRROR_URL` node-build env var
 
 ### Integrity/signature check

--- a/bin/install
+++ b/bin/install
@@ -43,13 +43,14 @@ install_canon_version() {
   local install_type="$1" version="$2" install_path="$3"
   local args=()
 
-  if [ "$install_type" = ref ]; then
+  if [ "$install_type" = ref ] || [ "${ASDF_NODEJS_FORCE_COMPILE-}" ]; then
     args+=(-c)
   fi
 
   try_to_update_nodebuild
 
-  NODE_BUILD_BUILD_PATH="$ASDF_DOWNLOAD_PATH" NODE_BUILD_CACHE_PATH="$ASDF_DOWNLOAD_PATH" \
+  NODE_BUILD_BUILD_PATH="${NODE_BUILD_BUILD_PATH:-$ASDF_DOWNLOAD_PATH}" \
+    NODE_BUILD_CACHE_PATH="${NODE_BUILD_CACHE_PATH:-$ASDF_DOWNLOAD_PATH}" \
     nodebuild_wrapped ${args+"${args[@]}"} "$version" "$install_path"
 }
 

--- a/lib/commands/command-nodebuild.bash
+++ b/lib/commands/command-nodebuild.bash
@@ -5,7 +5,7 @@ set -eu -o pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../utils.sh"
 
 : "${ASDF_NODEJS_NODEBUILD_HOME=$ASDF_NODEJS_PLUGIN_DIR/.node-build}"
-: "${ASDF_NODEJS_CONCURRENCY=$((${ASDF_CONCURRENCY:-1} + 1 / 2))}"
+: "${ASDF_NODEJS_CONCURRENCY=$(((${ASDF_CONCURRENCY:-1} + 1) / 2))}"
 
 # node-build environment variables being overriden by asdf-nodejs
 export NODE_BUILD_CACHE_PATH="${NODE_BUILD_CACHE_PATH:-$ASDF_NODEJS_CACHE_DIR/node-build}"


### PR DESCRIPTION
The env variable is called `ASDF_NODEJS_FORCE_COMPILE`, anything aside from an empty value will trigger it. The options will force compilation from source even though pre-compiled binaries are available.