### PR TITLE
feat: add comments to default npm packages

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -94,26 +94,32 @@ resolve_version_query() {
 
 
 install_default_npm_packages() {
-  local default_npm_packages="${ASDF_NPM_DEFAULT_PACKAGES_FILE:=$HOME/.default-npm-packages}"
-  local name
+  local default_npm_packages_file="${ASDF_NPM_DEFAULT_PACKAGES_FILE:=$HOME/.default-npm-packages}" filtered_packages=
 
-  if [ ! -f "$default_npm_packages" ]; then return; fi
+  if ! [ -f "$default_npm_packages_file" ]; then
+    return 0
+  fi
 
-  while read -r name; do
+  filtered_packages=$(grep -vE "^\s*#" < "$default_npm_packages_file")
+
+  if [ "${filtered_packages-}" ]; then 
+    printf "$(colored $CYAN "Installing the following default packages globally: ")"
+    xargs printf "%s, " <<< "$filtered_packages"
+    printf "\x8\x8 \n" # Cleanup last comma
+
     (
-      printf "Installing $(colored $YELLOW %s) npm package...\n" "$name"
-      source "$(dirname "$0")/exec-env"
-      PATH="$ASDF_INSTALL_PATH/bin:$PATH" npm install -g "$name" > /dev/null 2>&1 && rc=$? || rc=$?
-      if [[ $rc -eq 0 ]]; then
-        printf "$(colored $GREEN SUCCESS)\n"
-      else
-        printf "$(colored $RED FAIL)\n"
+      if [ -r "$ASDF_NODEJS_PLUGIN_DIR/bin/exec-env" ]; then
+        . "$ASDF_NODEJS_PLUGIN_DIR/bin/exec-env"
       fi
+
+      xargs env PATH="$ASDF_INSTALL_PATH/bin:$PATH" npm install -g <<< "$filtered_packages"
     )
-  done < "$default_npm_packages"
+  fi
 }
 
 install_nodejs "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
-install_default_npm_packages
+
+install_default_npm_packages \
+  || printf "\n$(colored $YELLOW WARNING:) An error occurred when installing the default npm packages, but Node's installation succeeded\n"
 
 asdf reshim "$(plugin_name)" "$ASDF_INSTALL_VERSION"


### PR DESCRIPTION
This PR adds comments to the `.default-npm-packages` file. Any line that starts with an `#` (optionally preceded by spaces) will be ignored. I also simplified the installation process to a single `npm install` instead of running it for each listed package. Running a single npm install might hit some unexpected problems (as mentioned in https://github.com/asdf-vm/asdf-nodejs/issues/280#issuecomment-1034384686), so we will need to take a closer look at any problems that arise.

Closes #280