### PR TITLE
if a version is not installable via node-build, make sure it is not in list-all

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -28,7 +28,7 @@ try_to_update_nodebuild() {
     printf "
 $(colored $YELLOW WARNING): Updating node-build failed with exit code %s. The installation will
 try to continue with already installed local defintions. To debug what went
-wrong try to manually updating node-build by running: \`asdf %s update nodebuild\`
+wrong, try to manually update node-build by running: \`asdf %s update nodebuild\`
 \n" "$exit_code" "$ASDF_NODEJS_PLUGIN_NAME"
   fi
 }
@@ -101,7 +101,7 @@ install_default_npm_packages() {
 
   filtered_packages=$(grep -vE "^\s*#" < "$default_npm_packages_file")
 
-  if [ "${filtered_packages-}" ]; then 
+  if [ "${filtered_packages-}" ]; then
     printf "$(colored $CYAN "Installing the following default packages globally: ")"
     xargs printf "%s, " <<< "$filtered_packages"
     printf "\x8\x8 \n" # Cleanup last comma

--- a/bin/install
+++ b/bin/install
@@ -34,11 +34,6 @@ wrong, try to manually update node-build by running: \`asdf %s update nodebuild\
 }
 
 
-nodebuild_wrapped() {
-  "$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-nodebuild.bash" "$@"
-}
-
-
 install_canon_version() {
   local install_type="$1" version="$2" install_path="$3"
   local args=()

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,8 +12,16 @@ set -o nounset -o pipefail -o errexit
 # shellcheck source=../lib/utils.sh
 source "$(dirname "$0")/../lib/utils.sh"
 
+function print_only_fully_numeric_items() {
+  local version_numbers="$1"
+  grep -E '^[0-9.]+$' <<< "$version_numbers"
+}
+
+asdf_nodejs_bin_dir="$(dirname "$0")"
+all_definitions_from_node_build="$("${asdf_nodejs_bin_dir}/../.node-build/bin/node-build" --definitions)"
+
 # Print
 echo $(
-  # Only print the first column of candidates
-  print_index_tab | cut -f1 | tac
+  printf "%s\n" lts-{argon,boron,carbon,dubnium,erbium,fermium,gallium} lts
+  print_only_fully_numeric_items "$all_definitions_from_node_build"
 )

--- a/bin/list-all
+++ b/bin/list-all
@@ -17,6 +17,8 @@ function print_only_fully_numeric_items() {
   grep -E '^[0-9.]+$' <<< "$version_numbers"
 }
 
+"$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-update-nodebuild.bash" &> /dev/null
+
 all_definitions_from_node_build="$(nodebuild_wrapped --definitions)"
 
 # Print

--- a/bin/list-all
+++ b/bin/list-all
@@ -17,11 +17,10 @@ function print_only_fully_numeric_items() {
   grep -E '^[0-9.]+$' <<< "$version_numbers"
 }
 
-asdf_nodejs_bin_dir="$(dirname "$0")"
-all_definitions_from_node_build="$("${asdf_nodejs_bin_dir}/../.node-build/bin/node-build" --definitions)"
+all_definitions_from_node_build="$("$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-nodebuild.bash"--definitions)"
 
 # Print
 echo $(
-  printf "%s\n" lts-{argon,boron,carbon,dubnium,erbium,fermium,gallium} lts
   print_only_fully_numeric_items "$all_definitions_from_node_build"
+  printf "%s\n" lts-{argon,boron,carbon,dubnium,erbium,fermium,gallium} lts
 )

--- a/bin/list-all
+++ b/bin/list-all
@@ -17,7 +17,7 @@ function print_only_fully_numeric_items() {
   grep -E '^[0-9.]+$' <<< "$version_numbers"
 }
 
-all_definitions_from_node_build="$("$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-nodebuild.bash"--definitions)"
+all_definitions_from_node_build="$(nodebuild_wrapped --definitions)"
 
 # Print
 echo $(

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -97,3 +97,7 @@ print_index_tab(){
 
   rm "$temp_headers_file"
 }
+
+nodebuild_wrapped() {
+  "$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-nodebuild.bash" "$@"
+}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -40,7 +40,6 @@ die() {
 # Print all alias and correspondent versions in the format "$alias\t$version"
 # Also prints versions as a alias of itself. Eg: "v10.0.0\tv10.0.0"
 filter_version_candidates() {
-  local version_definitions_available_in_local_node_build="$1"
   local curr_line="" aliases=""
 
   # Skip headers
@@ -52,34 +51,24 @@ filter_version_candidates() {
 
     # Version without `v` prefix
     local version="${fields[0]#v}"
+    # Lowercase lts codename, `-` if not a lts version
+    local lts_codename=$(echo "${fields[9]}" | tr '[:upper:]' '[:lower:]')
 
-    # if we couldn't find version_definitions_available_in_local_node_build, then just don't filter using that.
-    # filtering by version_definitions_available_in_local_node_build prevents situations like the following, where:
-    #   asdf list-all nodejs # returns 17.7.1
-    # but
-    #   asdf install nodejs 17.7.1
-    # doesn't work because the local version of node-build doesn't include the
-    # definition for 17.7.1 yet (as was the case on 2022-03011).
-    if [[ -z "$version_definitions_available_in_local_node_build" ]] || grep -Eq "^${version}$" <<< "$version_definitions_available_in_local_node_build"; then
-      # Lowercase lts codename, `-` if not a lts version
-      local lts_codename=$(echo "${fields[9]}" | tr '[:upper:]' '[:lower:]')
-
-      if [ "$lts_codename" != - ]; then
-        # No lts read yet, so this must be the more recent
-        if ! grep -q "^lts:" <<< "$aliases"; then
-          printf "lts\t%s\n" "$version"
-          aliases="$aliases"$'\n'"lts:$version"
-        fi
-
-        # No lts read for this codename yet, so this must be the more recent
-        if ! grep -q "^$lts_codename:" <<< "$aliases"; then
-          printf "lts-$lts_codename\t%s\n" "$version"
-          aliases="$aliases"$'\n'"$lts_codename:$version"
-        fi
+    if [ "$lts_codename" != - ]; then
+      # No lts read yet, so this must be the more recent
+      if ! grep -q "^lts:" <<< "$aliases"; then
+        printf "lts\t%s\n" "$version"
+        aliases="$aliases"$'\n'"lts:$version"
       fi
 
-      printf "%s\t%s\n" "$version" "$version"
+      # No lts read for this codename yet, so this must be the more recent
+      if ! grep -q "^$lts_codename:" <<< "$aliases"; then
+        printf "lts-$lts_codename\t%s\n" "$version"
+        aliases="$aliases"$'\n'"$lts_codename:$version"
+      fi
     fi
+
+    printf "%s\t%s\n" "$version" "$version"
   done
 }
 
@@ -97,18 +86,12 @@ print_index_tab(){
     etag_flag='--header If-None-Match:'"$(cat "$etag_file")"
   fi
 
-  local asdf_nodejs_bin_dir
-  asdf_nodejs_bin_dir="$(dirname "$0")"
-  local definitions_available_in_local_node_build=""
-  if [[ -f "${asdf_nodejs_bin_dir}/../.node-build/bin/node-build" ]]; then
-    definitions_available_in_local_node_build="$("${asdf_nodejs_bin_dir}/../.node-build/bin/node-build" --definitions)"
-  fi
   index="$(curl --fail --silent --dump-header "$temp_headers_file" $etag_flag  "${NODEJS_ORG_MIRROR}index.tab")"
   if [ -z "$index" ]; then
     cat "$index_file"
   else
     cat "$temp_headers_file" | awk 'tolower($1) == "etag:" { print $2 }' > "$etag_file"
-    echo "$index" | filter_version_candidates "$definitions_available_in_local_node_build" > "$index_file"
+    echo "$index" | filter_version_candidates > "$index_file"
     cat "$index_file"
   fi
 


### PR DESCRIPTION
this intends to fix the issue that caused the build failure in https://github.com/asdf-vm/asdf-nodejs/runs/5504696864. it also happened when several of my colleagues tried to run our [local dev setup script](https://github.com/no-term-limits/no-term-limits). doh. :) the only change between the previous output of `asdf list-all nodejs` and the output produced by the new version is that the following versions no longer appear:

````
17.7.0
17.7.1
````