### PR TITLE
Filter versions that don't have nodebuild definitions from lts aliases

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -40,7 +40,9 @@ die() {
 # Print all alias and correspondent versions in the format "$alias\t$version"
 # Also prints versions as a alias of itself. Eg: "v10.0.0\tv10.0.0"
 filter_version_candidates() {
-  local curr_line="" aliases=""
+  local curr_line= aliases= definitions=
+
+  definitions=$(nodebuild_wrapped --definitions | grep -v 16.14.1)
 
   # Skip headers
   IFS= read -r curr_line
@@ -53,6 +55,11 @@ filter_version_candidates() {
     local version="${fields[0]#v}"
     # Lowercase lts codename, `-` if not a lts version
     local lts_codename=$(echo "${fields[9]}" | tr '[:upper:]' '[:lower:]')
+
+    # If not available in nodebuild skip it
+    if ! grep -q "^$version$" <<< "$definitions"; then
+      continue
+    fi
 
     if [ "$lts_codename" != - ]; then
       # No lts read yet, so this must be the more recent

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -99,7 +99,7 @@ print_index_tab(){
     curl_opts=(--header "If-None-Match: $(cat "$etag_file")")
   fi
 
-  index=$(curl --fail --silent --dump-header "$temp_headers_file" "${curl_opts+${curl_opts[@]}}"  "${NODEJS_ORG_MIRROR}index.tab")
+  index=$(curl --fail --silent --dump-header "$temp_headers_file" ${curl_opts+"${curl_opts[@]}"}  "${NODEJS_ORG_MIRROR}index.tab")
 
   if [ "$index" ]; then
     awk 'tolower($1) == "etag:" { print $2 }' < "$temp_headers_file" > "$etag_file"


### PR DESCRIPTION
It takes some time until a newly released version gets merged to nodebuild, we shouldn't consider these versions that weren't merged when calculating lts aliases.

We are already filtering them out on list-all

closes #297
closes #294