### PR TITLE
fix: add cat to circumvent printf's broken pipe on bash3

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -106,7 +106,9 @@ print_index_tab(){
     printf "%s\n" "$index" > "$index_file"
   fi
 
-  filter_version_candidates < "$index_file"
+  # The `cat` indirection is for a bash3 printf broken pipe error
+  # https://github.com/asdf-vm/asdf-nodejs/issues/300
+  cat <(filter_version_candidates < "$index_file")
 }
 
 nodebuild_wrapped() {


### PR DESCRIPTION
Add a pipe indirection so it doesn't trigger an pipe broken warning on bash 3

closes #300