### PR TITLE
feat: add the `hydrogen` LTS codename (node v18)

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -24,5 +24,5 @@ all_definitions_from_node_build="$(nodebuild_wrapped --definitions)"
 # Print
 echo $(
   print_only_fully_numeric_items "$all_definitions_from_node_build"
-  printf "%s\n" lts-{argon,boron,carbon,dubnium,erbium,fermium,gallium} lts
+  printf "%s\n" lts-{argon,boron,carbon,dubnium,erbium,fermium,gallium,hydrogen} lts
 )


### PR DESCRIPTION
`asdf install` does work for alias `lts-hydrogen`, but it does not display it when running `asdf list-all nodejs`. This makes it clear that it is indeed a supported LTS alias.