### PR TITLE
Install most recent point release of inexact versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -46,6 +46,8 @@ install_canon_version() {
 
   NODE_BUILD_CACHE_PATH="${NODE_BUILD_CACHE_PATH:-$ASDF_DOWNLOAD_PATH}" \
     nodebuild_wrapped ${args+"${args[@]}"} "$version" "$install_path"
+
+  update_version_symlinks "$(dirname $install_path)"
 }
 
 
@@ -80,7 +82,13 @@ resolve_version_query() {
   )"
 
   if [ -z "$canon_version" ]; then
-    echo "$version_query"
+    local latest_point_version="$(
+      # Find the latest point release (e.g., a version_query of 16.10 can find 16.10.2)
+      print_index_tab |
+        egrep "^${version_query}\.[0-9\.]+	" -m1 |
+        awk -F'\t' '{ print $2; exit }'
+    )"
+    echo "${latest_point_version:-$version_query}"
   else
     echo "$canon_version"
   fi

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Unoffical Bash "strict mode"
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+
+IFS=$'\t\n' # Stricter IFS settings
+
+
+# shellcheck source=bin/utils.sh
+source "$(dirname "$0")/../lib/utils.sh"
+
+rm -rf "$ASDF_INSTALL_PATH" || true
+
+update_version_symlinks "$(dirname "$ASDF_INSTALL_PATH")"


### PR DESCRIPTION
This change will make it such that when installing a version like so:

`asdf install nodejs 16.10`

It would install 16.10.3 (assuming 16.10.3 is the latest point release at the time of installation).  **This change allows asdf to work better with legacy version specifiers such as what would be stored in `.nvmrc`.**

For this to work properly, it would also (in the example above), symlink 16.10 to point to 16.10.3 (and likewise to link 16 to 16.10.3).  Such symlinks are expected to point to the latest version installed that satisfies the partial version number.

An uninstallation script has to be added so that symlinks aren't left dangling at any point.

This fix addresses issue #295.