### PR TITLE
Fix unable to install aliased version on first install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -42,8 +42,6 @@ install_canon_version() {
     args+=(-c)
   fi
 
-  try_to_update_nodebuild
-
   NODE_BUILD_CACHE_PATH="${NODE_BUILD_CACHE_PATH:-$ASDF_DOWNLOAD_PATH}" \
     nodebuild_wrapped ${args+"${args[@]}"} "$version" "$install_path"
 }
@@ -110,6 +108,8 @@ install_default_npm_packages() {
     )
   fi
 }
+
+try_to_update_nodebuild
 
 install_nodejs "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
 


### PR DESCRIPTION
Fix https://github.com/asdf-vm/asdf-nodejs/issues/329 and https://github.com/asdf-vm/asdf-nodejs/issues/319

The `resolve_version_query` function in the install script requires node-build in order to resolve an alias, but node-build isn't installed/updated until after `resolve_version_query` is called.

This PR ensures node-build is installed/updated earlier, so aliases are correctly handled on first install.

Before:
![image](https://user-images.githubusercontent.com/1320357/212568467-fe1dc9c0-71da-44e1-b1b5-0f5e70354a18.png)

After:
![image](https://user-images.githubusercontent.com/1320357/212569237-a7d4b996-2418-4d6e-baa6-f70f267de9a5.png)
