### PR TITLE
Add "--location" to curl_opts

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -96,10 +96,10 @@ print_index_tab(){
   delete_on_exit "$temp_headers_file"
 
   if [ -r "$etag_file" ]; then
-    curl_opts=(--location --header "If-None-Match: $(cat "$etag_file")")
+    curl_opts=(--header "If-None-Match: $(cat "$etag_file")")
   fi
 
-  index=$(curl --fail --silent --dump-header "$temp_headers_file" ${curl_opts+"${curl_opts[@]}"}  "${NODEJS_ORG_MIRROR}index.tab")
+  index=$(curl --fail --silent --location --dump-header "$temp_headers_file" ${curl_opts+"${curl_opts[@]}"}  "${NODEJS_ORG_MIRROR}index.tab")
 
   if [ "$index" ]; then
     awk 'tolower($1) == "etag:" { print $2 }' < "$temp_headers_file" > "$etag_file"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -96,7 +96,7 @@ print_index_tab(){
   delete_on_exit "$temp_headers_file"
 
   if [ -r "$etag_file" ]; then
-    curl_opts=(--header "If-None-Match: $(cat "$etag_file")")
+    curl_opts=(--location --header "If-None-Match: $(cat "$etag_file")")
   fi
 
   index=$(curl --fail --silent --dump-header "$temp_headers_file" ${curl_opts+"${curl_opts[@]}"}  "${NODEJS_ORG_MIRROR}index.tab")


### PR DESCRIPTION
If set `NODEJS_ORG_MIRROR` to `npmmirror.com`, there would be a 302 response.

```bash
export NODEJS_ORG_MIRROR='https://npmmirror.com/mirrors/node/'

asdf list all nodejs
```

Add `--location` option to follow redirects.