### PR TITLE
fix config vars docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When compiling a version from source, you are going to need to install [all requ
 - `ASDF_NODEJS_VERBOSE_INSTALL`: Enables verbose output for downloading and building. Any value different from empty is treated as enabled.
 - `ASDF_NODEJS_FORCE_COMPILE`: Forces compilation from source instead of preferring pre-compiled binaries
 - `ASDF_NODEJS_NODEBUILD_HOME`: Home for the node-build installation, defaults to `$ASDF_DIR/plugins/nodejs/.node-build`, you can install it in another place or share it with your system
-- `ASDF_NODEJS_NODEBUILD`: Path to the node-build executable, defaults to `$NODE_BUILD_MIRROR_URL/bin/node-build`
+- `ASDF_NODEJS_NODEBUILD`: Path to the node-build executable, defaults to `$ASDF_NODEJS_NODEBUILD_HOME/bin/node-build`
 - `ASDF_NODEJS_CONCURRENCY`: How many jobs should be used in compilation. Defaults to half the computer cores
 - `NODEJS_ORG_MIRROR`: (Legacy) overrides the default mirror used for downloading the distibutions, alternative to the `NODE_BUILD_MIRROR_URL` node-build env var
 


### PR DESCRIPTION
stated default for ASDF_NODEJS_NODEBUILD was different than actual code, see https://github.com/asdf-vm/asdf-nodejs/blob/c9e5df443b932f22e79e178a52866b053065be80/lib/commands/command-nodebuild.bash#L22