### PR TITLE
docs: update installation to match asdf v0.5.0 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Node.js plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 After installing [asdf](https://github.com/asdf-vm/asdf), install the plugin by running:
 
 ```bash
-asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 ```
 
 ## Use


### PR DESCRIPTION
docs: update installation to match asdf v0.5.0 command

asdf v0.5.0 tells you to manage plugins using the format `asdf plugin-{command} ...` rather than `asdf plugin {command} ...`