### PR TITLE
bug: give full path to asdf

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -51,4 +51,4 @@ install_nodejs "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
 install_default_npm_packages \
   || printf "\n$(colored $YELLOW WARNING:) An error occurred when installing the default npm packages, but Node's installation succeeded\n"
 
-asdf reshim "$(plugin_name)" "$ASDF_INSTALL_VERSION"
+$ASDF_DIR/bin/asdf reshim "$(plugin_name)" "$ASDF_INSTALL_VERSION"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -8,6 +8,7 @@ if [ ${NODEJS_ORG_MIRROR: -1} != / ]; then
 fi
 
 export ASDF_NODEJS_PLUGIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export ASDF_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 
 # TODO: Replace with an asdf variable once asdf starts providing the plugin name
 # as a variable


### PR DESCRIPTION
In some use cases, such as scripted install, asdf is not yet added to PATH. 
Determine ASDF_DIR and give full pathname of asdf in bin/install.