### PR TITLE
fix: unable to resolve latest LTS version correctly

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -145,6 +145,9 @@ resolve_version() {
 
   if [ "$query" = lts ] || [ "$query" = "lts/*" ]; then
     query="${nodejs_codenames[${#nodejs_codenames[@]} - 1]#*:}"
+    local all_versions
+    all_versions=$("$ASDF_NODEJS_PLUGIN_DIR/bin/list-all" 2>/dev/null | tr ' ' '\n')
+    query=$(echo "$all_versions" | grep "^$query\." | tail -n1)
   fi
 
   if [ "${ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY-}" ]; then


### PR DESCRIPTION
Currently asdf-nodejs can not resolve lts correctly, it will only return the code number.
<img width="648" alt="image" src="https://github.com/asdf-vm/asdf-nodejs/assets/64841155/307a6165-a002-48c6-9dfa-635903667581">
After the fix, the plugin can resolve it correctly.
<img width="649" alt="image" src="https://github.com/asdf-vm/asdf-nodejs/assets/64841155/28b5ef02-ade1-4926-bb57-04a045d17af6">
