### PR TITLE
Add NodeJS LTS 22 series

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ This plugin adds a custom subcommand `asdf nodejs resolve lts`. If you want to k
 asdf nodejs update-nodebuild
 
 asdf nodejs resolve lts
-# outputs: 20.9.0
+# outputs: 22.11.0
 ```
 You also have the option of forcing a resolution strategy by using the flags `--latest-installed` and `--latest-available`
 ```bash

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -137,6 +137,7 @@ resolve_version() {
     gallium:16
     hydrogen:18
     iron:20
+    jod:22
   )
 
   for cod_version in "${nodejs_codenames[@]}"; do


### PR DESCRIPTION
Used the same approach as for 20 (https://github.com/asdf-vm/asdf-nodejs/pull/377).

Seems like `node-build` needs to be updated, but once https://github.com/nodenv/node-build/pull/956 is merged, I think this can be merged.