### PR TITLE
Fix plugin for v0.16 of asdf and lts resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This plugin adds a custom subcommand `asdf cmd nodejs resolve lts`. If you want 
 asdf cmd nodejs update-nodebuild
 
 asdf cmd nodejs resolve lts
-# outputs: 22.11.0
+# outputs: 22.13.1
 ```
 
 You also have the option of forcing a resolution strategy by using the flags `--latest-installed` and `--latest-available`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can specify a non-default location of this file by setting a `ASDF_NPM_DEFAU
 We provide a command for running the installed `node-build` command:
 
 ```bash
-asdf nodejs nodebuild --version
+asdf cmd nodejs nodebuild --version
 ```
 
 ### node-build advanced variations
@@ -122,7 +122,7 @@ Some of them will work out of the box, and some will need a bit of investigation
 To list all the available variations run:
 
 ```bash
-asdf nodejs nodebuild --definitions
+asdf cmd nodejs nodebuild --definitions
 ```
 
 _Note that this command only lists the current `node-build` definitions. You might want to [update the local `node-build` repository](#updating-node-build-definitions) before listing them._
@@ -132,7 +132,7 @@ _Note that this command only lists the current `node-build` definitions. You mig
 Every new node version needs to have a definition file in the `node-build` repository. `asdf-nodejs` already tries to update `node-build` on every new version installation, but if you want to update `node-build` manually for some reason we provide a command just for that:
 
 ```bash
-asdf nodejs update-nodebuild
+asdf cmd nodejs update-nodebuild
 ```
 
 ### Integrity/signature check
@@ -141,21 +141,24 @@ In the past `asdf-nodejs` checked for signatures and integrity by querying live 
 
 ### Resolving latest available LTS version in a script
 
-This plugin adds a custom subcommand `asdf nodejs resolve lts`. If you want to know what is the latest available LTS major version number you can do this:
+This plugin adds a custom subcommand `asdf cmd nodejs resolve lts`. If you want to know what is the latest available LTS major version number you can do this:
+
 ```sh
 # Before checking for aliases, update nodebuild to check for newly releasead versions
-asdf nodejs update-nodebuild
+asdf cmd nodejs update-nodebuild
 
-asdf nodejs resolve lts
+asdf cmd nodejs resolve lts
 # outputs: 22.11.0
 ```
+
 You also have the option of forcing a resolution strategy by using the flags `--latest-installed` and `--latest-available`
+
 ```bash
 # Outputs the latest version installed locally which is a LTS
-asdf nodejs resolve lts --latest-installed
+asdf cmd nodejs resolve lts --latest-installed
 
 # Outputs the latest version available for download which is a LTS
-asdf nodejs resolve lts --latest-available
+asdf cmd nodejs resolve lts --latest-available
 ```
 
 ## Corepack

--- a/lib/commands/command-nodebuild
+++ b/lib/commands/command-nodebuild
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/lib/commands/command-resolve
+++ b/lib/commands/command-resolve
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/lib/commands/command-update-nodebuild
+++ b/lib/commands/command-update-nodebuild
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -41,7 +41,7 @@ colored() {
 export RED=31 GREEN=32 YELLOW=33 BLUE=34 MAGENTA=35 CYAN=36
 
 nodebuild_wrapped() {
-  "$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-nodebuild.bash" "$@"
+  "$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-nodebuild" "$@"
 }
 
 try_to_update_nodebuild() {
@@ -51,7 +51,7 @@ try_to_update_nodebuild() {
 
   local exit_code=0
 
-  "$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-update-nodebuild.bash" 2>/dev/null || exit_code=$?
+  "$ASDF_NODEJS_PLUGIN_DIR/lib/commands/command-update-nodebuild" 2>/dev/null || exit_code=$?
 
   if [ "$exit_code" != 0 ]; then
     printf "
@@ -152,6 +152,9 @@ resolve_version() {
 
   if [ "$query" = lts ] || [ "$query" = "lts/*" ]; then
     query="${nodejs_codenames[${#nodejs_codenames[@]} - 1]#*:}"
+    local all_versions
+    all_versions=$("$ASDF_NODEJS_PLUGIN_DIR/bin/list-all" 2>/dev/null | tr ' ' '\n')
+    query=$(echo "$all_versions" | grep "^$query\." | tail -n1)
   fi
 
   if [ "${ASDF_NODEJS_LEGACY_FILE_DYNAMIC_STRATEGY-}" ]; then


### PR DESCRIPTION
- Fixed permission issue on resolve command
- Fixed command names, removed `.bash` 
    - https://asdf-vm.com/guide/upgrading-to-v0-16.html#extension-commands-have-been-redesigned
    - A more complete version of #410 
- Fixed lts resolution (taken from #393 since that one seems stale)

I know this is duplicated stuff, but I just wanted the plugin working locally and these changes seem to fix everything for v0.16 that I ran into