### PR TITLE
Reset nodebuild when trying to update it

### DIFF
--- a/lib/commands/command-update-nodebuild
+++ b/lib/commands/command-update-nodebuild
@@ -9,7 +9,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../utils.sh"
 : "${ASDF_NODEJS_NODEBUILD_BRANCH=main}"
 
 ensure_updated_project() {
-  local pull_exit_code=0 output=
+  local pull_exit_code=0 output=''
 
   if ! [ -d "$ASDF_NODEJS_NODEBUILD_HOME" ]; then
     printf "Cloning node-build...\n"
@@ -26,6 +26,10 @@ ensure_updated_project() {
       printf "Please check if the git repository at %s doesn't have any changes or anything\nthat might not allow a git pull\n" "$ASDF_NODEJS_NODEBUILD_HOME" >&2
       exit $pull_exit_code
     fi
+
+    # For some time, asdf-core was cleaning up the node-build directory by accident
+    # This is a workaround to restore the files that were deleted
+    git -C "$ASDF_NODEJS_NODEBUILD_HOME" checkout HEAD .
 
     printf " ok\n"
   fi

--- a/lib/commands/command-update-nodebuild
+++ b/lib/commands/command-update-nodebuild
@@ -9,27 +9,27 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../utils.sh"
 : "${ASDF_NODEJS_NODEBUILD_BRANCH=main}"
 
 ensure_updated_project() {
-  local pull_exit_code=0 output=''
+  local pull_exit_code=0
 
   if ! [ -d "$ASDF_NODEJS_NODEBUILD_HOME" ]; then
     printf "Cloning node-build...\n"
     git clone "$ASDF_NODEJS_NODEBUILD_REPOSITORY" "$ASDF_NODEJS_NODEBUILD_HOME" --branch "$ASDF_NODEJS_NODEBUILD_BRANCH"
   else
-    git -C "$ASDF_NODEJS_NODEBUILD_HOME" checkout "$ASDF_NODEJS_NODEBUILD_BRANCH"
-
     printf "Trying to update node-build..."
-    output=$(git -C "$ASDF_NODEJS_NODEBUILD_HOME" pull origin 2>&1) || pull_exit_code=$?
+    git -C "$ASDF_NODEJS_NODEBUILD_HOME" fetch origin "$ASDF_NODEJS_NODEBUILD_BRANCH" >&2 || pull_exit_code=$?
+    git -C "$ASDF_NODEJS_NODEBUILD_HOME" checkout "$ASDF_NODEJS_NODEBUILD_BRANCH" >&2 || true
 
     if [ "$pull_exit_code" != 0 ]; then
-      printf "\n%s\n\n" "$output" >&2
-      printf "$(colored $RED ERROR): Pulling the node-build repository exited with code %s\n" "$pull_exit_code" >&2
-      printf "Please check if the git repository at %s doesn't have any changes or anything\nthat might not allow a git pull\n" "$ASDF_NODEJS_NODEBUILD_HOME" >&2
+      printf "$(colored $RED ERROR): Pulling the node-build repository exited with code %s\n" "$pull_exit_code"
+      printf "Please check if the git repository at %s doesn't have any changes or anything\nthat might not allow a git pull\n" "$ASDF_NODEJS_NODEBUILD_HOME"
       exit $pull_exit_code
     fi
 
     # For some time, asdf-core was cleaning up the node-build directory by accident
     # This is a workaround to restore the files that were deleted
-    git -C "$ASDF_NODEJS_NODEBUILD_HOME" checkout HEAD .
+    if ! [ -f "$ASDF_NODEJS_NODEBUILD_HOME/bin/nodebuild" ]; then
+      git -C "$ASDF_NODEJS_NODEBUILD_HOME" checkout HEAD . >&2
+    fi
 
     printf " ok\n"
   fi

--- a/lib/commands/command-update-nodebuild
+++ b/lib/commands/command-update-nodebuild
@@ -6,16 +6,19 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../utils.sh"
 
 : "${ASDF_NODEJS_NODEBUILD_HOME=$ASDF_NODEJS_PLUGIN_DIR/.node-build}"
 : "${ASDF_NODEJS_NODEBUILD_REPOSITORY=https://github.com/nodenv/node-build.git}"
+: "${ASDF_NODEJS_NODEBUILD_BRANCH=main}"
 
 ensure_updated_project() {
   local pull_exit_code=0 output=
 
   if ! [ -d "$ASDF_NODEJS_NODEBUILD_HOME" ]; then
     printf "Cloning node-build...\n"
-    git clone "$ASDF_NODEJS_NODEBUILD_REPOSITORY" "$ASDF_NODEJS_NODEBUILD_HOME"
+    git clone "$ASDF_NODEJS_NODEBUILD_REPOSITORY" "$ASDF_NODEJS_NODEBUILD_HOME" --branch "$ASDF_NODEJS_NODEBUILD_BRANCH"
   else
+    git -C "$ASDF_NODEJS_NODEBUILD_HOME" checkout "$ASDF_NODEJS_NODEBUILD_BRANCH"
+
     printf "Trying to update node-build..."
-    output=$(git -C "$ASDF_NODEJS_NODEBUILD_HOME" pull origin master 2>&1) || pull_exit_code=$?
+    output=$(git -C "$ASDF_NODEJS_NODEBUILD_HOME" pull origin 2>&1) || pull_exit_code=$?
 
     if [ "$pull_exit_code" != 0 ]; then
       printf "\n%s\n\n" "$output" >&2


### PR DESCRIPTION
Some versions of asdf-core reset the nodebuild directory when updating asdf-nodejs, even though this is fixed now, some people still have older versions of the install that have the `.node-build` directory still clean