### PR TITLE
Prefer asdf when searching for an installed version of npm

### DIFF
--- a/shims/npm
+++ b/shims/npm
@@ -128,7 +128,7 @@ manually_search_npm_bin() {
 
   for bin_dir in "${bin_directories[@]}"; do
     if [ -x "$installed_dir/$bin_dir/npm" ]; then
-      printf "%s\n" "$installed_dir/$bin_dir/npm" 
+      printf "%s\n" "$installed_dir/$bin_dir/npm"
       return 0
     fi
   done

--- a/shims/npm
+++ b/shims/npm
@@ -78,7 +78,7 @@ resolve_canon_npm() {
   # Try searching in current path (asdf core from 0.7 onwards adds all binaries candidates directories to PATH)
   # if that doesn't works (when calling the shim directly for example) it tries manually searching the binary in
   # the installed version provided by "asdf where"
-  npm_location="${ASDF_NODEJS_CANON_NPM_PATH:-$(search_npm_on_current_path || manually_search_npm_bin)}"
+  npm_location="${ASDF_NODEJS_CANON_NPM_PATH:-$(manually_search_npm_bin || search_npm_on_current_path)}"
 
   if ! [ "$npm_location" ]; then
     printf "asdf-nodejs couldn't find a suitable npm executable\n"


### PR DESCRIPTION
I _think_ this is a fix to the NPM detection flow, which prefers the currently selected, `asdf`-installed version of NPM over some other, globally installed version of NPM.

Context, I have `asdf` installed on Ubuntu under WSL2, and I have global installation of NPM in Windows. WSL2 adds my Windows path to `$PATH`, but I don't want `asdf` to detect that when selecting a version of node, so I'd rather bias it to the one selected via `asdf where nodejs`. This _might_ fix the longstanding #271, but that's seen zero activity in 4 years, so I don't even know if that's still an issue.